### PR TITLE
External task comms

### DIFF
--- a/acomm/README.md
+++ b/acomm/README.md
@@ -133,7 +133,7 @@ appropriately to handle a response.
 #### func  NewRequest
 
 ```go
-func NewRequest(task, responseHook, streamURL string, args interface{}, sh ResponseHandler, eh ResponseHandler) (*Request, error)
+func NewRequest(task string) *Request
 ```
 NewRequest creates a new Request instance.
 
@@ -151,7 +151,29 @@ assumed no handling is necessary and silently finishes.
 ```go
 func (req *Request) Respond(resp *Response) error
 ```
-Respond sends a Response to a Request's ResponseHook.
+Respond sends a Response to the ResponseHook if present.
+
+#### func (*Request) SetArgs
+
+```go
+func (req *Request) SetArgs(args interface{}) error
+```
+SetArgs sets the Args.
+
+#### func (*Request) SetResponseHook
+
+```go
+func (req *Request) SetResponseHook(urlString string) error
+```
+SetResponseHook is a convenience method to set the ResponseHook from a string
+url.
+
+#### func (*Request) SetStreamURL
+
+```go
+func (req *Request) SetStreamURL(urlString string) error
+```
+SetStreamURL is a convenience method to set the StreamURL from a string url.
 
 #### func (*Request) UnmarshalArgs
 

--- a/acomm/README.md
+++ b/acomm/README.md
@@ -117,8 +117,8 @@ Responses returns responses for all of the requests, keyed on the request name
 type Request struct {
 	ID             string           `json:"id"`
 	Task           string           `json:"task"`
-	ResponseHook   *url.URL         `json:"responsehook"`
-	StreamURL      *url.URL         `json:"stream_url"`
+	ResponseHook   *url.URL         `json:"responseHook"`
+	StreamURL      *url.URL         `json:"streamURL"`
 	Args           *json.RawMessage `json:"args"`
 	SuccessHandler ResponseHandler  `json:"-"`
 	ErrorHandler   ResponseHandler  `json:"-"`
@@ -195,7 +195,7 @@ Validate validates the reqeust
 type Response struct {
 	ID        string           `json:"id"`
 	Result    *json.RawMessage `json:"result"`
-	StreamURL *url.URL         `json:"stream_url"`
+	StreamURL *url.URL         `json:"streamURL"`
 	Error     error            `json:"error"`
 }
 ```

--- a/acomm/README.md
+++ b/acomm/README.md
@@ -134,7 +134,7 @@ appropriately to handle a response.
 #### func  NewRequest
 
 ```go
-func NewRequest(opts *RequestOptions) (*Request, error)
+func NewRequest(opts RequestOptions) (*Request, error)
 ```
 NewRequest creates a new Request instance.
 

--- a/acomm/README.md
+++ b/acomm/README.md
@@ -117,6 +117,7 @@ Responses returns responses for all of the requests, keyed on the request name
 type Request struct {
 	ID             string           `json:"id"`
 	Task           string           `json:"task"`
+	TaskURL        *url.URL         `json:"taskURL"`
 	ResponseHook   *url.URL         `json:"responseHook"`
 	StreamURL      *url.URL         `json:"streamURL"`
 	Args           *json.RawMessage `json:"args"`
@@ -174,6 +175,13 @@ url.
 func (req *Request) SetStreamURL(urlString string) error
 ```
 SetStreamURL is a convenience method to set the StreamURL from a string url.
+
+#### func (*Request) SetTaskURL
+
+```go
+func (req *Request) SetTaskURL(urlString string) error
+```
+SetTaskURL is a convenience method to set the TaskURL from a string url.
 
 #### func (*Request) UnmarshalArgs
 

--- a/acomm/README.md
+++ b/acomm/README.md
@@ -134,7 +134,7 @@ appropriately to handle a response.
 #### func  NewRequest
 
 ```go
-func NewRequest(task string) *Request
+func NewRequest(opts *RequestOptions) (*Request, error)
 ```
 NewRequest creates a new Request instance.
 
@@ -196,6 +196,27 @@ UnmarshalArgs unmarshals the request args into the destination object.
 func (req *Request) Validate() error
 ```
 Validate validates the reqeust
+
+#### type RequestOptions
+
+```go
+type RequestOptions struct {
+	Task               string
+	TaskURL            *url.URL
+	TaskURLString      string
+	ResponseHook       *url.URL
+	ResponseHookString string
+	StreamURL          *url.URL
+	StreamURLString    string
+	Args               interface{}
+	SuccessHandler     ResponseHandler
+	ErrorHandler       ResponseHandler
+}
+```
+
+RequestOptions are properties and options used to create a new Request object.
+There are options to either directly specify a URL or provide a string that will
+be parsed.
 
 #### type Response
 

--- a/acomm/README.md
+++ b/acomm/README.md
@@ -260,7 +260,7 @@ Tracker keeps track of requests waiting on a response.
 #### func  NewTracker
 
 ```go
-func NewTracker(socketPath string, httpStreamURL *url.URL, defaultTimeout time.Duration) (*Tracker, error)
+func NewTracker(socketPath string, httpStreamURL, externalProxyURL *url.URL, defaultTimeout time.Duration) (*Tracker, error)
 ```
 NewTracker creates and initializes a new Tracker. If a socketPath is not
 provided, the response socket will be created in a temporary directory.
@@ -294,6 +294,20 @@ NewStreamUnix sets up an ad-hoc unix listner to stream data.
 func (t *Tracker) NumRequests() int
 ```
 NumRequests returns the number of tracked requests
+
+#### func (*Tracker) ProxyExternal
+
+```go
+func (t *Tracker) ProxyExternal(req *Request, timeout time.Duration) (*Request, error)
+```
+ProxyExternal proxies a request intended for an external destination
+
+#### func (*Tracker) ProxyExternalHandler
+
+```go
+func (t *Tracker) ProxyExternalHandler(w http.ResponseWriter, r *http.Request)
+```
+ProxyExternalHandler is an HTTP HandlerFunc for proxying an external request.
 
 #### func (*Tracker) ProxyStreamHTTPURL
 

--- a/acomm/request.go
+++ b/acomm/request.go
@@ -47,11 +47,7 @@ type RequestOptions struct {
 type ResponseHandler func(*Request, *Response)
 
 // NewRequest creates a new Request instance.
-func NewRequest(opts *RequestOptions) (*Request, error) {
-	if opts == nil {
-		return nil, errors.New("missing request options")
-	}
-
+func NewRequest(opts RequestOptions) (*Request, error) {
 	req := &Request{
 		ID:             uuid.New(),
 		Task:           opts.Task,

--- a/acomm/request.go
+++ b/acomm/request.go
@@ -17,8 +17,8 @@ import (
 type Request struct {
 	ID             string           `json:"id"`
 	Task           string           `json:"task"`
-	ResponseHook   *url.URL         `json:"responsehook"`
-	StreamURL      *url.URL         `json:"stream_url"`
+	ResponseHook   *url.URL         `json:"responseHook"`
+	StreamURL      *url.URL         `json:"streamURL"`
 	Args           *json.RawMessage `json:"args"`
 	SuccessHandler ResponseHandler  `json:"-"`
 	ErrorHandler   ResponseHandler  `json:"-"`

--- a/acomm/request.go
+++ b/acomm/request.go
@@ -17,6 +17,7 @@ import (
 type Request struct {
 	ID             string           `json:"id"`
 	Task           string           `json:"task"`
+	TaskURL        *url.URL         `json:"taskURL"`
 	ResponseHook   *url.URL         `json:"responseHook"`
 	StreamURL      *url.URL         `json:"streamURL"`
 	Args           *json.RawMessage `json:"args"`
@@ -65,6 +66,21 @@ func (req *Request) SetStreamURL(urlString string) error {
 	}
 
 	req.StreamURL = streamURL
+	return nil
+}
+
+// SetTaskURL is a convenience method to set the TaskURL from a string url.
+func (req *Request) SetTaskURL(urlString string) error {
+	taskURL, err := url.ParseRequestURI(urlString)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"taskURL": urlString,
+		}).Error("invalid task url")
+		return err
+	}
+
+	req.TaskURL = taskURL
 	return nil
 }
 

--- a/acomm/request_test.go
+++ b/acomm/request_test.go
@@ -101,6 +101,34 @@ func (s *RequestTestSuite) TestSetStreamURL() {
 	}
 }
 
+func (s *RequestTestSuite) TestSetTaskURL() {
+	tests := []struct {
+		description string
+		taskURL     string
+		expectedErr bool
+	}{
+		{"empty", "", true},
+		{"invalid", "asdf", true},
+		{"unix", "unix://asdf", false},
+		{"http", "http://asdf", false},
+		{"https", "https://asdf", false},
+	}
+
+	for _, test := range tests {
+		msg := testMsgFunc(test.description)
+		req := &acomm.Request{}
+		err := req.SetTaskURL(test.taskURL)
+		if test.expectedErr {
+			s.Error(err, msg("should have errored"))
+			s.Nil(req.TaskURL, msg("should not have set task url"))
+		} else {
+			s.NoError(err, msg("should not have errored"))
+			s.NotNil(req.TaskURL, msg("should have set task url"))
+			s.Equal(test.taskURL, req.TaskURL.String(), msg("should be equivalent task urls"))
+		}
+	}
+}
+
 func (s *RequestTestSuite) TestSetArgs() {
 	tests := []struct {
 		description string

--- a/acomm/request_test.go
+++ b/acomm/request_test.go
@@ -37,23 +37,22 @@ func (s *RequestTestSuite) TestNewRequest() {
 
 	tests := []struct {
 		description string
-		opts        *acomm.RequestOptions
+		opts        acomm.RequestOptions
 		expectedErr bool
 	}{
-		{"nil options", nil, true},
-		{"empty options", &acomm.RequestOptions{}, true},
-		{"task", &acomm.RequestOptions{Task: task}, false},
-		{"args", &acomm.RequestOptions{Task: task, Args: args}, false},
-		{"invalid response hook string", &acomm.RequestOptions{Task: task, ResponseHookString: "asdf"}, true},
-		{"valid response hook string", &acomm.RequestOptions{Task: task, ResponseHookString: "unix://asdf"}, false},
-		{"valid response hook url", &acomm.RequestOptions{Task: task, ResponseHook: unixURL}, false},
-		{"invalid task url string", &acomm.RequestOptions{Task: task, TaskURLString: "asdf"}, true},
-		{"valid task url string", &acomm.RequestOptions{Task: task, TaskURLString: "unix://asdf"}, false},
-		{"valid task url url", &acomm.RequestOptions{Task: task, TaskURL: unixURL}, false},
-		{"invalid stream url string", &acomm.RequestOptions{Task: task, StreamURLString: "asdf"}, true},
-		{"valid stream url string", &acomm.RequestOptions{Task: task, StreamURLString: "unix://asdf"}, false},
-		{"valid stream url url", &acomm.RequestOptions{Task: task, StreamURL: unixURL}, false},
-		{"success and error handlers", &acomm.RequestOptions{Task: task, SuccessHandler: sh, ErrorHandler: eh}, false},
+		{"empty options", acomm.RequestOptions{}, true},
+		{"task", acomm.RequestOptions{Task: task}, false},
+		{"args", acomm.RequestOptions{Task: task, Args: args}, false},
+		{"invalid response hook string", acomm.RequestOptions{Task: task, ResponseHookString: "asdf"}, true},
+		{"valid response hook string", acomm.RequestOptions{Task: task, ResponseHookString: "unix://asdf"}, false},
+		{"valid response hook url", acomm.RequestOptions{Task: task, ResponseHook: unixURL}, false},
+		{"invalid task url string", acomm.RequestOptions{Task: task, TaskURLString: "asdf"}, true},
+		{"valid task url string", acomm.RequestOptions{Task: task, TaskURLString: "unix://asdf"}, false},
+		{"valid task url url", acomm.RequestOptions{Task: task, TaskURL: unixURL}, false},
+		{"invalid stream url string", acomm.RequestOptions{Task: task, StreamURLString: "asdf"}, true},
+		{"valid stream url string", acomm.RequestOptions{Task: task, StreamURLString: "unix://asdf"}, false},
+		{"valid stream url url", acomm.RequestOptions{Task: task, StreamURL: unixURL}, false},
+		{"success and error handlers", acomm.RequestOptions{Task: task, SuccessHandler: sh, ErrorHandler: eh}, false},
 	}
 
 	for _, test := range tests {
@@ -229,7 +228,7 @@ func (s *RequestTestSuite) TestHandleResponse() {
 		handled["success"] = 0
 		handled["error"] = 0
 		msg := testMsgFunc(test.description)
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:           "foobar",
 			Args:           struct{}{},
 			SuccessHandler: test.sh,

--- a/acomm/request_test.go
+++ b/acomm/request_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"reflect"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -26,69 +25,96 @@ func TestRequestTestSuite(t *testing.T) {
 }
 
 func (s *RequestTestSuite) TestNewRequest() {
-	task := "foobar"
-	args := map[string]string{
-		"foo": "bar",
-	}
-
-	sh, eh, _ := generateHandlers()
-
 	tests := []struct {
-		description  string
-		task         string
-		responseHook string
-		streamURL    string
-		args         interface{}
-		sh           acomm.ResponseHandler
-		eh           acomm.ResponseHandler
-		expectedErr  bool
+		description string
+		task        string
 	}{
-		{"missing response hook", task, "", "", args, sh, eh, true},
-		{"invalid response hook", task, "asdf", "", args, sh, eh, true},
-		{"missing args", task, "unix://asdf", "", nil, sh, eh, false},
-		{"unix hook and args", task, "unix://asdf", "", args, sh, eh, false},
-		{"http hook and args", task, "http://asdf", "", args, sh, eh, false},
-		{"https hook and args", task, "https://asdf", "", args, sh, eh, false},
-		{"unix stream", task, "unix://asdf", "unix://asdf", args, sh, eh, false},
-		{"http stream", task, "http://asdf", "http://asdf", args, sh, eh, false},
-		{"https stream", task, "https://asdf", "https://asdf", args, sh, eh, false},
-		{"unix hook, args, no handlers", task, "unix://asdf", "", args, nil, nil, false},
-		{"unix hook, args, sh handler", task, "unix://asdf", "", args, sh, nil, false},
-		{"unix hook, args, eh handler", task, "unix://asdf", "", args, nil, eh, false},
-		{"missing task ", "", "unix://asdf", "", args, sh, eh, true},
+		{"without task", ""},
+		{"with task", "foobar"},
 	}
 
 	for _, test := range tests {
 		msg := testMsgFunc(test.description)
-		req, err := acomm.NewRequest(test.task, test.responseHook, test.streamURL, test.args, test.sh, test.eh)
-		if test.expectedErr {
-			s.Error(err, msg("should have failed"))
-			s.Nil(req, msg("should not have returned a request"))
-		} else {
-			if !s.NoError(err, msg("should have succeeded")) {
-				s.T().Log(msg(err.Error()))
-				continue
-			}
-			if !s.NotNil(req, msg("should have returned a request")) {
-				continue
-			}
-
-			s.NotEmpty(req.ID, msg("should have set an ID"))
-			s.Equal(test.task, req.Task, msg("should have set the task"))
-			s.Equal(test.responseHook, req.ResponseHook.String(), msg("should have set the response hook"))
-			if test.streamURL != "" {
-				s.Equal(test.streamURL, req.StreamURL.String(), msg("should have set the stream url"))
-			}
-			var args map[string]string
-			s.NoError(req.UnmarshalArgs(&args))
-			if test.args == nil {
-				s.Nil(args, msg("should have nil arguments"))
-			} else {
-				s.Equal(test.args, args, msg("should have set the arguments"))
-			}
-			s.Equal(reflect.ValueOf(test.sh).Pointer(), reflect.ValueOf(req.SuccessHandler).Pointer(), msg("should have set success handler"))
-			s.Equal(reflect.ValueOf(test.eh).Pointer(), reflect.ValueOf(req.ErrorHandler).Pointer(), msg("should have set error handler"))
+		req := acomm.NewRequest(test.task)
+		if !s.NotNil(req, msg("should have returned a request")) {
+			continue
 		}
+
+		s.NotEmpty(req.ID, msg("should have set an ID"))
+		s.Equal(test.task, req.Task, msg("should have set the task"))
+	}
+}
+
+func (s *RequestTestSuite) TestSetResponseHook() {
+	tests := []struct {
+		description  string
+		responseHook string
+		expectedErr  bool
+	}{
+		{"empty", "", true},
+		{"invalid", "asdf", true},
+		{"unix", "unix://asdf", false},
+		{"http", "http://asdf", false},
+		{"https", "https://asdf", false},
+	}
+
+	for _, test := range tests {
+		msg := testMsgFunc(test.description)
+		req := &acomm.Request{}
+		err := req.SetResponseHook(test.responseHook)
+		if test.expectedErr {
+			s.Error(err, msg("should have errored"))
+			s.Nil(req.ResponseHook, msg("should not have set response hook"))
+		} else {
+			s.NoError(err, msg("should not have errored"))
+			s.NotNil(req.ResponseHook, msg("should have set response hook"))
+			s.Equal(test.responseHook, req.ResponseHook.String(), msg("should be equivalent response hooks"))
+		}
+	}
+}
+
+func (s *RequestTestSuite) TestSetStreamURL() {
+	tests := []struct {
+		description string
+		streamURL   string
+		expectedErr bool
+	}{
+		{"empty", "", true},
+		{"invalid", "asdf", true},
+		{"unix", "unix://asdf", false},
+		{"http", "http://asdf", false},
+		{"https", "https://asdf", false},
+	}
+
+	for _, test := range tests {
+		msg := testMsgFunc(test.description)
+		req := &acomm.Request{}
+		err := req.SetStreamURL(test.streamURL)
+		if test.expectedErr {
+			s.Error(err, msg("should have errored"))
+			s.Nil(req.StreamURL, msg("should not have set stream url"))
+		} else {
+			s.NoError(err, msg("should not have errored"))
+			s.NotNil(req.StreamURL, msg("should have set stream url"))
+			s.Equal(test.streamURL, req.StreamURL.String(), msg("should be equivalent stream urls"))
+		}
+	}
+}
+
+func (s *RequestTestSuite) TestSetArgs() {
+	tests := []struct {
+		description string
+		args        interface{}
+	}{
+		{"nil", nil},
+		{"map", map[string]string{"foo": "bar"}},
+	}
+
+	for _, test := range tests {
+		msg := testMsgFunc(test.description)
+		req := &acomm.Request{}
+		s.NoError(req.SetArgs(test.args), msg("should not error"))
+		s.NotNil(req.Args, msg("should have set args"))
 	}
 }
 
@@ -115,10 +141,11 @@ func (s *RequestTestSuite) TestHandleResponse() {
 		handled["success"] = 0
 		handled["error"] = 0
 		msg := testMsgFunc(test.description)
-		req, err := acomm.NewRequest("foobar", "unix://foo", "", struct{}{}, test.sh, test.eh)
-		if !s.NoError(err, msg("should not fail to build req")) {
-			continue
-		}
+		req := acomm.NewRequest("foobar")
+		_ = req.SetArgs(struct{}{})
+		req.SuccessHandler = test.sh
+		req.ErrorHandler = test.eh
+
 		resp, err := acomm.NewResponse(req, test.respResult, nil, test.respErr)
 		if !s.NoError(err, msg("should not fail to build resp")) {
 			continue
@@ -155,7 +182,7 @@ func (s *RequestTestSuite) TestValidate() {
 	}{
 		{"missing ID", "", "foo", rh, true},
 		{"missing Task", uuid.New(), "", rh, true},
-		{"missing ResponseHook", uuid.New(), "foo", nil, true},
+		{"missing ResponseHook", uuid.New(), "foo", nil, false},
 		{"valid", uuid.New(), "foo", rh, false},
 	}
 

--- a/acomm/response.go
+++ b/acomm/response.go
@@ -19,7 +19,7 @@ import (
 type Response struct {
 	ID        string           `json:"id"`
 	Result    *json.RawMessage `json:"result"`
-	StreamURL *url.URL         `json:"stream_url"`
+	StreamURL *url.URL         `json:"streamURL"`
 	Error     error            `json:"error"`
 }
 

--- a/acomm/response_test.go
+++ b/acomm/response_test.go
@@ -41,7 +41,7 @@ func (s *ResponseTestSuite) TestNewResponse() {
 		"foo": "bar",
 	}
 
-	request, _ := acomm.NewRequest("foobar", "unix://foo", "", nil, nil, nil)
+	request := acomm.NewRequest("foobar")
 	respErr := errors.New("foobar")
 
 	tests := []struct {

--- a/acomm/response_test.go
+++ b/acomm/response_test.go
@@ -41,7 +41,7 @@ func (s *ResponseTestSuite) TestNewResponse() {
 		"foo": "bar",
 	}
 
-	request, err := acomm.NewRequest(&acomm.RequestOptions{Task: "foobar"})
+	request, err := acomm.NewRequest(acomm.RequestOptions{Task: "foobar"})
 	s.Require().NoError(err, "should have created request")
 	respErr := errors.New("foobar")
 

--- a/acomm/response_test.go
+++ b/acomm/response_test.go
@@ -41,7 +41,8 @@ func (s *ResponseTestSuite) TestNewResponse() {
 		"foo": "bar",
 	}
 
-	request := acomm.NewRequest("foobar")
+	request, err := acomm.NewRequest(&acomm.RequestOptions{Task: "foobar"})
+	s.Require().NoError(err, "should have created request")
 	respErr := errors.New("foobar")
 
 	tests := []struct {

--- a/acomm/tracker.go
+++ b/acomm/tracker.go
@@ -1,11 +1,13 @@
 package acomm
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"sync"
@@ -26,6 +28,7 @@ type Tracker struct {
 	status           int
 	responseListener *UnixListener
 	httpStreamURL    *url.URL
+	externalProxyURL *url.URL
 	defaultTimeout   time.Duration
 	requestsLock     sync.Mutex // Protects requests
 	requests         map[string]*Request
@@ -36,7 +39,7 @@ type Tracker struct {
 
 // NewTracker creates and initializes a new Tracker. If a socketPath is not
 // provided, the response socket will be created in a temporary directory.
-func NewTracker(socketPath string, httpStreamURL *url.URL, defaultTimeout time.Duration) (*Tracker, error) {
+func NewTracker(socketPath string, httpStreamURL, externalProxyURL *url.URL, defaultTimeout time.Duration) (*Tracker, error) {
 	if socketPath == "" {
 		var err error
 		socketPath, err = generateTempSocketPath("", "acommTrackerResponses-")
@@ -53,6 +56,7 @@ func NewTracker(socketPath string, httpStreamURL *url.URL, defaultTimeout time.D
 		status:           statusStopped,
 		responseListener: NewUnixListener(socketPath, 0),
 		httpStreamURL:    httpStreamURL,
+		externalProxyURL: externalProxyURL,
 		dataStreams:      make(map[string]*UnixListener),
 		defaultTimeout:   defaultTimeout,
 	}, nil
@@ -363,4 +367,69 @@ func (t *Tracker) ProxyUnix(req *Request, timeout time.Duration) (*Request, erro
 	}
 
 	return unixReq, nil
+}
+
+// ProxyExternal proxies a request intended for an external destination
+func (t *Tracker) ProxyExternal(req *Request, timeout time.Duration) (*Request, error) {
+	if t.externalProxyURL == nil {
+		err := errors.New("tracker missing external proxy url")
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Error(err)
+		return nil, err
+	}
+	if t.responseListener == nil {
+		err := errors.New("request tracker's response listener not active")
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Error(err)
+		return nil, err
+	}
+
+	externalReq := &Request{
+		ID:           req.ID,
+		Task:         req.Task,
+		ResponseHook: t.externalProxyURL,
+		StreamURL:    req.StreamURL,
+		Args:         req.Args,
+	}
+	if err := t.TrackRequest(req, timeout); err != nil {
+		return nil, err
+	}
+	req.proxied = true
+
+	return externalReq, nil
+}
+
+// ProxyExternalHandler is an HTTP HandlerFunc for proxying an external request.
+func (t *Tracker) ProxyExternalHandler(w http.ResponseWriter, r *http.Request) {
+	resp := &Response{}
+	body, err := ioutil.ReadAll(r.Body)
+	if err == nil {
+		err = json.Unmarshal(body, resp)
+	}
+
+	ack := &Response{
+		Error: err,
+	}
+	ackJSON, err := json.Marshal(ack)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"ack":   ack,
+		}).Error("failed to marshal ack")
+		return
+	}
+	if _, err := w.Write(ackJSON); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"ack":   ack,
+		}).Error("failed to ack response")
+		return
+	}
+
+	if ack.Error != nil {
+		return
+	}
+	t.HandleResponse(resp)
 }

--- a/acomm/tracker.go
+++ b/acomm/tracker.go
@@ -390,9 +390,16 @@ func (t *Tracker) ProxyExternal(req *Request, timeout time.Duration) (*Request, 
 		ID:           req.ID,
 		Task:         req.Task,
 		ResponseHook: t.externalProxyURL,
-		StreamURL:    req.StreamURL,
 		Args:         req.Args,
 	}
+	if req.StreamURL != nil {
+		streamURL, err := t.ProxyStreamHTTPURL(req.StreamURL) // Replace the StreamURL with a proxy stream url
+		if err != nil {
+			return nil, err
+		}
+		externalReq.StreamURL = streamURL
+	}
+
 	if err := t.TrackRequest(req, timeout); err != nil {
 		return nil, err
 	}

--- a/acomm/tracker.go
+++ b/acomm/tracker.go
@@ -411,13 +411,9 @@ func (t *Tracker) ProxyExternal(req *Request, timeout time.Duration) (*Request, 
 // ProxyExternalHandler is an HTTP HandlerFunc for proxying an external request.
 func (t *Tracker) ProxyExternalHandler(w http.ResponseWriter, r *http.Request) {
 	resp := &Response{}
-	body, err := ioutil.ReadAll(r.Body)
-	if err == nil {
-		err = json.Unmarshal(body, resp)
-	}
-
+	decoder := json.NewDecoder(r.Body)
 	ack := &Response{
-		Error: err,
+		Error: decoder.Decode(resp),
 	}
 	ackJSON, err := json.Marshal(ack)
 	if err != nil {

--- a/acomm/tracker_test.go
+++ b/acomm/tracker_test.go
@@ -51,7 +51,7 @@ func (s *TrackerTestSuite) SetupSuite() {
 func (s *TrackerTestSuite) SetupTest() {
 	var err error
 
-	s.Request, err = acomm.NewRequest(&acomm.RequestOptions{
+	s.Request, err = acomm.NewRequest(acomm.RequestOptions{
 		Task:               "foobar",
 		ResponseHookString: s.RespServer.URL,
 	})
@@ -132,7 +132,7 @@ func (s *TrackerTestSuite) TestProxyUnix() {
 	}))
 	defer streamServer.Close()
 
-	req, err := acomm.NewRequest(&acomm.RequestOptions{
+	req, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:               "foobar",
 		ResponseHookString: s.RespServer.URL,
 		StreamURLString:    streamServer.URL,
@@ -166,7 +166,7 @@ func (s *TrackerTestSuite) TestProxyUnix() {
 	s.Equal(0, s.Tracker.NumRequests(), "should have removed the request from tracking")
 
 	// Should not proxy a request already using unix response hook
-	origUnixReq, err := acomm.NewRequest(&acomm.RequestOptions{
+	origUnixReq, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:               "foobar",
 		ResponseHookString: "unix://foo",
 		Args:               struct{}{},
@@ -183,7 +183,7 @@ func (s *TrackerTestSuite) TestProxyExternal() {
 		return
 	}
 
-	origReq, err := acomm.NewRequest(&acomm.RequestOptions{
+	origReq, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:               "foobar",
 		ResponseHookString: s.RespServer.URL,
 		Args:               struct{}{},

--- a/acomm/tracker_test.go
+++ b/acomm/tracker_test.go
@@ -45,8 +45,8 @@ func (s *TrackerTestSuite) SetupSuite() {
 func (s *TrackerTestSuite) SetupTest() {
 	var err error
 
-	s.Request, err = acomm.NewRequest("foobar", s.RespServer.URL, "", nil, nil, nil)
-	s.Require().NoError(err, "request should be valid")
+	s.Request = acomm.NewRequest("foobar")
+	s.Require().NoError(s.Request.SetResponseHook(s.RespServer.URL), "response hook should be set")
 
 	streamAddr, _ := url.ParseRequestURI(s.StreamServer.URL)
 	s.Tracker, err = acomm.NewTracker("", streamAddr, 0)
@@ -119,8 +119,9 @@ func (s *TrackerTestSuite) TestProxyUnix() {
 	}))
 	defer streamServer.Close()
 
-	req, err := acomm.NewRequest("foobar", s.RespServer.URL, streamServer.URL, nil, nil, nil)
-	s.NoError(err)
+	req := acomm.NewRequest("foobar")
+	s.NoError(req.SetResponseHook(s.RespServer.URL))
+	s.NoError(req.SetStreamURL(streamServer.URL))
 
 	unixReq, err = s.Tracker.ProxyUnix(req, 0)
 	s.NoError(err, "should not fail proxying when tracker is listening")
@@ -149,10 +150,9 @@ func (s *TrackerTestSuite) TestProxyUnix() {
 	s.Equal(0, s.Tracker.NumRequests(), "should have removed the request from tracking")
 
 	// Should not proxy a request already using unix response hook
-	origUnixReq, err := acomm.NewRequest("foobar", "unix://foo", "", struct{}{}, nil, nil)
-	if !s.NoError(err, "new request shoudl not error") {
-		return
-	}
+	origUnixReq := acomm.NewRequest("foobar")
+	_ = origUnixReq.SetResponseHook("unix://foo")
+	_ = origUnixReq.SetArgs(struct{}{})
 	unixReq, err = s.Tracker.ProxyUnix(origUnixReq, 0)
 	s.NoError(err, "should not error with unix response hook")
 	s.Equal(origUnixReq, unixReq, "should not proxy unix response hook")

--- a/cmd/coordinator-cli/main.go
+++ b/cmd/coordinator-cli/main.go
@@ -185,8 +185,14 @@ func makeRequest(coordinator, taskName, httpAddr string, stream bool, taskArgs m
 	if stream {
 		streamURL = fmt.Sprintf("http://%s/stream", httpAddr)
 	}
-	req, err := acomm.NewRequest(taskName, responseHook, streamURL, taskArgs, nil, nil)
-	if err != nil {
+	req := acomm.NewRequest(taskName)
+	if err := req.SetResponseHook(responseHook); err != nil {
+		return err
+	}
+	if err := req.SetStreamURL(streamURL); err != nil {
+		return err
+	}
+	if err := req.SetArgs(taskArgs); err != nil {
 		return err
 	}
 

--- a/cmd/coordinator-cli/main.go
+++ b/cmd/coordinator-cli/main.go
@@ -186,17 +186,14 @@ func makeRequest(coordinator, taskName, httpAddr, taskURL string, stream bool, t
 	if stream {
 		streamURL = fmt.Sprintf("http://%s/stream", httpAddr)
 	}
-	req := acomm.NewRequest(taskName)
-	if err := req.SetResponseHook(responseHook); err != nil {
-		return err
-	}
-	if err := req.SetStreamURL(streamURL); streamURL != "" && err != nil {
-		return err
-	}
-	if err := req.SetArgs(taskArgs); err != nil {
-		return err
-	}
-	if err := req.SetTaskURL(taskURL); taskURL != "" && err != nil {
+	req, err := acomm.NewRequest(&acomm.RequestOptions{
+		Task:               taskName,
+		ResponseHookString: responseHook,
+		StreamURLString:    streamURL,
+		Args:               taskArgs,
+		TaskURLString:      taskURL,
+	})
+	if err != nil {
 		return err
 	}
 

--- a/cmd/coordinator-cli/main.go
+++ b/cmd/coordinator-cli/main.go
@@ -186,7 +186,7 @@ func makeRequest(coordinator, taskName, httpAddr, taskURL string, stream bool, t
 	if stream {
 		streamURL = fmt.Sprintf("http://%s/stream", httpAddr)
 	}
-	req, err := acomm.NewRequest(&acomm.RequestOptions{
+	req, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:               taskName,
 		ResponseHookString: responseHook,
 		StreamURLString:    streamURL,

--- a/cmd/metrics-provider/README.md
+++ b/cmd/metrics-provider/README.md
@@ -1,0 +1,9 @@
+# metrics-provider
+
+[![metrics-provider](https://godoc.org/github.com/cerana/cerana/cmd/metrics-provider?status.png)](https://godoc.org/github.com/cerana/cerana/cmd/metrics-provider)
+
+
+
+
+--
+*Generated with [godocdown](https://github.com/robertkrimen/godocdown)*

--- a/coordinator/server.go
+++ b/coordinator/server.go
@@ -53,15 +53,13 @@ func NewServer(config *Config) (*Server, error) {
 		"response",
 		config.ServiceName()+".sock")
 
-	streamURL, err := url.ParseRequestURI(
-		fmt.Sprintf("http://%s:%d/stream", getLocalIP(), config.ExternalPort()))
+	streamURL, err := url.ParseRequestURI(fmt.Sprintf("http://%s:%d/stream", getLocalIP(), config.ExternalPort()))
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
 		}).Error("failed to generate stream url")
 	}
-	proxyURL, err := url.ParseRequestURI(
-		fmt.Sprintf("http://%s:%d/proxy", getLocalIP(), config.ExternalPort()))
+	proxyURL, err := url.ParseRequestURI(fmt.Sprintf("http://%s:%d/proxy", getLocalIP(), config.ExternalPort()))
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,

--- a/coordinator/server_test.go
+++ b/coordinator/server_test.go
@@ -139,7 +139,9 @@ func (s *ServerSuite) TestReqRespHandle() {
 			coordinatorURL = internalURL
 		}
 
-		req, _ := acomm.NewRequest(test.taskName, hookURL, "", test.params, nil, nil)
+		req := acomm.NewRequest(test.taskName)
+		_ = req.SetResponseHook(hookURL)
+		_ = req.SetArgs(test.params)
 		if err := acomm.Send(coordinatorURL, req); err != nil {
 			result <- nil
 		}

--- a/coordinator/server_test.go
+++ b/coordinator/server_test.go
@@ -139,7 +139,7 @@ func (s *ServerSuite) TestReqRespHandle() {
 			coordinatorURL = internalURL
 		}
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:               test.taskName,
 			ResponseHookString: hookURL,
 			Args:               test.params,

--- a/coordinator/server_test.go
+++ b/coordinator/server_test.go
@@ -139,9 +139,13 @@ func (s *ServerSuite) TestReqRespHandle() {
 			coordinatorURL = internalURL
 		}
 
-		req := acomm.NewRequest(test.taskName)
-		_ = req.SetResponseHook(hookURL)
-		_ = req.SetArgs(test.params)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:               test.taskName,
+			ResponseHookString: hookURL,
+			Args:               test.params,
+		})
+		s.Require().NoError(err, msg("should have created req"))
+
 		if err := acomm.Send(coordinatorURL, req); err != nil {
 			result <- nil
 		}

--- a/provider/examples/simple/simple.go
+++ b/provider/examples/simple/simple.go
@@ -100,12 +100,15 @@ func (s *Simple) SystemStatus(req *acomm.Request) (interface{}, *url.URL, error)
 	// Prepare multiple requests
 	multiRequest := acomm.NewMultiRequest(s.tracker, 0)
 
-	cpuReq, err := acomm.NewRequest("CPUInfo", s.tracker.URL().String(), "", &CPUInfoArgs{GuestID: args.GuestID}, nil, nil)
-	if err != nil {
+	cpuReq := acomm.NewRequest("CPUInfo")
+	cpuReq.ResponseHook = s.tracker.URL()
+	if err := cpuReq.SetArgs(&CPUInfoArgs{GuestID: args.GuestID}); err != nil {
 		return nil, nil, err
 	}
-	diskReq, err := acomm.NewRequest("DiskInfo", s.tracker.URL().String(), "", &DiskInfoArgs{GuestID: args.GuestID}, nil, nil)
-	if err != nil {
+
+	diskReq := acomm.NewRequest("DiskInfo")
+	diskReq.ResponseHook = s.tracker.URL()
+	if err := diskReq.SetArgs(&DiskInfoArgs{GuestID: args.GuestID}); err != nil {
 		return nil, nil, err
 	}
 

--- a/provider/examples/simple/simple.go
+++ b/provider/examples/simple/simple.go
@@ -100,7 +100,7 @@ func (s *Simple) SystemStatus(req *acomm.Request) (interface{}, *url.URL, error)
 	// Prepare multiple requests
 	multiRequest := acomm.NewMultiRequest(s.tracker, 0)
 
-	cpuReq, err := acomm.NewRequest(&acomm.RequestOptions{
+	cpuReq, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:         "CPUInfo",
 		ResponseHook: s.tracker.URL(),
 		Args:         &CPUInfoArgs{GuestID: args.GuestID},
@@ -109,7 +109,7 @@ func (s *Simple) SystemStatus(req *acomm.Request) (interface{}, *url.URL, error)
 		return nil, nil, err
 	}
 
-	diskReq, err := acomm.NewRequest(&acomm.RequestOptions{
+	diskReq, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:         "DiskInfo",
 		ResponseHook: s.tracker.URL(),
 		Args:         &DiskInfoArgs{GuestID: args.GuestID},

--- a/provider/examples/simple/simple.go
+++ b/provider/examples/simple/simple.go
@@ -100,15 +100,21 @@ func (s *Simple) SystemStatus(req *acomm.Request) (interface{}, *url.URL, error)
 	// Prepare multiple requests
 	multiRequest := acomm.NewMultiRequest(s.tracker, 0)
 
-	cpuReq := acomm.NewRequest("CPUInfo")
-	cpuReq.ResponseHook = s.tracker.URL()
-	if err := cpuReq.SetArgs(&CPUInfoArgs{GuestID: args.GuestID}); err != nil {
+	cpuReq, err := acomm.NewRequest(&acomm.RequestOptions{
+		Task:         "CPUInfo",
+		ResponseHook: s.tracker.URL(),
+		Args:         &CPUInfoArgs{GuestID: args.GuestID},
+	})
+	if err != nil {
 		return nil, nil, err
 	}
 
-	diskReq := acomm.NewRequest("DiskInfo")
-	diskReq.ResponseHook = s.tracker.URL()
-	if err := diskReq.SetArgs(&DiskInfoArgs{GuestID: args.GuestID}); err != nil {
+	diskReq, err := acomm.NewRequest(&acomm.RequestOptions{
+		Task:         "DiskInfo",
+		ResponseHook: s.tracker.URL(),
+		Args:         &DiskInfoArgs{GuestID: args.GuestID},
+	})
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/provider/server.go
+++ b/provider/server.go
@@ -35,7 +35,7 @@ func NewServer(config *Config) (*Server, error) {
 		config.SocketDir(),
 		"response",
 		config.ServiceName()+".sock")
-	tracker, err := acomm.NewTracker(responseSocket, nil, config.RequestTimeout())
+	tracker, err := acomm.NewTracker(responseSocket, nil, nil, config.RequestTimeout())
 	if err != nil {
 		return nil, err
 	}

--- a/provider/server_test.go
+++ b/provider/server_test.go
@@ -110,7 +110,7 @@ func (s *ServerSuite) TestStartHandleStop() {
 	respHandler := func(req *acomm.Request, resp *acomm.Response) {
 		close(handled)
 	}
-	req, err := acomm.NewRequest(&acomm.RequestOptions{
+	req, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:           "foobar",
 		ResponseHook:   tracker.URL(),
 		SuccessHandler: respHandler,

--- a/provider/server_test.go
+++ b/provider/server_test.go
@@ -110,10 +110,14 @@ func (s *ServerSuite) TestStartHandleStop() {
 	respHandler := func(req *acomm.Request, resp *acomm.Response) {
 		close(handled)
 	}
-	req := acomm.NewRequest("foobar")
-	req.ResponseHook = tracker.URL()
-	req.SuccessHandler = respHandler
-	req.ErrorHandler = respHandler
+	req, err := acomm.NewRequest(&acomm.RequestOptions{
+		Task:           "foobar",
+		ResponseHook:   tracker.URL(),
+		SuccessHandler: respHandler,
+		ErrorHandler:   respHandler,
+	})
+	s.Require().NoError(err)
+
 	providerSocket, _ := url.ParseRequestURI("unix://" + s.server.TaskSocketPath("foobar"))
 	if !s.NoError(s.server.Tracker().TrackRequest(req, 5*time.Second)) {
 		return

--- a/provider/server_test.go
+++ b/provider/server_test.go
@@ -110,7 +110,10 @@ func (s *ServerSuite) TestStartHandleStop() {
 	respHandler := func(req *acomm.Request, resp *acomm.Response) {
 		close(handled)
 	}
-	req, _ := acomm.NewRequest("foobar", tracker.URL().String(), "", struct{}{}, respHandler, respHandler)
+	req := acomm.NewRequest("foobar")
+	req.ResponseHook = tracker.URL()
+	req.SuccessHandler = respHandler
+	req.ErrorHandler = respHandler
 	providerSocket, _ := url.ParseRequestURI("unix://" + s.server.TaskSocketPath("foobar"))
 	if !s.NoError(s.server.Tracker().TrackRequest(req, 5*time.Second)) {
 		return

--- a/providers/metrics/README.md
+++ b/providers/metrics/README.md
@@ -1,0 +1,113 @@
+# metrics
+
+[![metrics](https://godoc.org/github.com/cerana/cerana/providers/metrics?status.png)](https://godoc.org/github.com/cerana/cerana/providers/metrics)
+
+
+
+## Usage
+
+#### type CPUResult
+
+```go
+type CPUResult struct {
+	Info  []cpu.InfoStat  `json:"info"`
+	Load  *load.AvgStat   `json:"load"`
+	Times []cpu.TimesStat `json:"times"`
+}
+```
+
+CPUResult is the result of the CPU handler.
+
+#### type DiskResult
+
+```go
+type DiskResult struct {
+	IO         map[string]disk.IOCountersStat `json:"io"`
+	Partitions []disk.PartitionStat           `json:"partitions"`
+	Usage      []*disk.UsageStat              `json:"usage"`
+}
+```
+
+DiskResult is the result for the Disk handler.
+
+#### type MemoryResult
+
+```go
+type MemoryResult struct {
+	Swap    *mem.SwapMemoryStat    `json:"swap"`
+	Virtual *mem.VirtualMemoryStat `json:"virtual"`
+}
+```
+
+MemoryResult is the result for the Memory handler.
+
+#### type Metrics
+
+```go
+type Metrics struct{}
+```
+
+Metrics is a provider of system info and metrics functionality.
+
+#### func (*Metrics) CPU
+
+```go
+func (m *Metrics) CPU(req *acomm.Request) (interface{}, *url.URL, error)
+```
+CPU returns information about the CPU hardware, times, and load.
+
+#### func (*Metrics) Disk
+
+```go
+func (m *Metrics) Disk(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Disk returns information about the disk partitions, io, and usage.
+
+#### func (*Metrics) Hardware
+
+```go
+func (m *Metrics) Hardware(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Hardware returns information about the hardware.
+
+#### func (*Metrics) Host
+
+```go
+func (m *Metrics) Host(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Host returns information about the host machine.
+
+#### func (*Metrics) Memory
+
+```go
+func (m *Metrics) Memory(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Memory returns information about the virtual and swap memory.
+
+#### func (*Metrics) Network
+
+```go
+func (m *Metrics) Network(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Network returns information about the net interfaces and io.
+
+#### func (*Metrics) RegisterTasks
+
+```go
+func (m *Metrics) RegisterTasks(server *provider.Server)
+```
+RegisterTasks registers all of Metric's task handlers with the server.
+
+#### type NetworkResult
+
+```go
+type NetworkResult struct {
+	IO         []net.IOCountersStat `json:"io"`
+	Interfaces []net.InterfaceStat  `json:"interfaces"`
+}
+```
+
+NetworkResult is the result for the Network handler.
+
+--
+*Generated with [godocdown](https://github.com/robertkrimen/godocdown)*

--- a/providers/systemd/action_test.go
+++ b/providers/systemd/action_test.go
@@ -38,7 +38,7 @@ func (s *systemd) TestActions() {
 		args := &systemdp.ActionArgs{Name: test.name, Mode: test.mode}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "systemd-" + test.action,
 			ResponseHook: s.responseHook,
 			Args:         args,

--- a/providers/systemd/action_test.go
+++ b/providers/systemd/action_test.go
@@ -38,8 +38,9 @@ func (s *systemd) TestActions() {
 		args := &systemdp.ActionArgs{Name: test.name, Mode: test.mode}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req, err := acomm.NewRequest("systemd-"+test.action, "unix:///tmp/foobar", "", args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("systemd-" + test.action)
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(args), argsS)
 
 		var fn func(*acomm.Request) (interface{}, *url.URL, error)
 		switch test.action {

--- a/providers/systemd/action_test.go
+++ b/providers/systemd/action_test.go
@@ -38,9 +38,12 @@ func (s *systemd) TestActions() {
 		args := &systemdp.ActionArgs{Name: test.name, Mode: test.mode}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req := acomm.NewRequest("systemd-" + test.action)
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "systemd-" + test.action,
+			ResponseHook: s.responseHook,
+			Args:         args,
+		})
+		s.Require().NoError(err, argsS)
 
 		var fn func(*acomm.Request) (interface{}, *url.URL, error)
 		switch test.action {

--- a/providers/systemd/create_test.go
+++ b/providers/systemd/create_test.go
@@ -26,7 +26,7 @@ func (s *systemd) TestCreate() {
 		args := &systemdp.CreateArgs{Name: test.name, UnitOptions: test.options}
 		argsS := fmt.Sprintf("%+v", args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "systemd-create",
 			ResponseHook: s.responseHook,
 			Args:         args,

--- a/providers/systemd/create_test.go
+++ b/providers/systemd/create_test.go
@@ -26,9 +26,12 @@ func (s *systemd) TestCreate() {
 		args := &systemdp.CreateArgs{Name: test.name, UnitOptions: test.options}
 		argsS := fmt.Sprintf("%+v", args)
 
-		req := acomm.NewRequest("systemd-create")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "systemd-create",
+			ResponseHook: s.responseHook,
+			Args:         args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.systemd.Create(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/create_test.go
+++ b/providers/systemd/create_test.go
@@ -25,8 +25,10 @@ func (s *systemd) TestCreate() {
 	for _, test := range tests {
 		args := &systemdp.CreateArgs{Name: test.name, UnitOptions: test.options}
 		argsS := fmt.Sprintf("%+v", args)
-		req, err := acomm.NewRequest("systemd-create", "unix:///tmp/foobar", "", args, nil, nil)
-		s.Require().NoError(err, argsS)
+
+		req := acomm.NewRequest("systemd-create")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(args), argsS)
 
 		res, streamURL, err := s.systemd.Create(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/disable_test.go
+++ b/providers/systemd/disable_test.go
@@ -27,9 +27,12 @@ func (s *systemd) TestDisable() {
 		args := &systemdp.DisableArgs{Name: test.name, Runtime: test.runtime}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req := acomm.NewRequest("systemd-disable")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "systemd-disable",
+			ResponseHook: s.responseHook,
+			Args:         args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.systemd.Disable(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/disable_test.go
+++ b/providers/systemd/disable_test.go
@@ -27,8 +27,9 @@ func (s *systemd) TestDisable() {
 		args := &systemdp.DisableArgs{Name: test.name, Runtime: test.runtime}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req, err := acomm.NewRequest("systemd-disable", "unix:///tmp/foobar", "", args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("systemd-disable")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(args), argsS)
 
 		res, streamURL, err := s.systemd.Disable(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/disable_test.go
+++ b/providers/systemd/disable_test.go
@@ -27,7 +27,7 @@ func (s *systemd) TestDisable() {
 		args := &systemdp.DisableArgs{Name: test.name, Runtime: test.runtime}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "systemd-disable",
 			ResponseHook: s.responseHook,
 			Args:         args,

--- a/providers/systemd/enable_test.go
+++ b/providers/systemd/enable_test.go
@@ -27,8 +27,9 @@ func (s *systemd) TestEnable() {
 		args := &systemdp.EnableArgs{Name: test.name, Runtime: test.runtime, Force: test.force}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req, err := acomm.NewRequest("systemd-enable", "unix:///tmp/foobar", "", args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("systemd-enable")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(args), argsS)
 
 		res, streamURL, err := s.systemd.Enable(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/enable_test.go
+++ b/providers/systemd/enable_test.go
@@ -26,10 +26,12 @@ func (s *systemd) TestEnable() {
 	for _, test := range tests {
 		args := &systemdp.EnableArgs{Name: test.name, Runtime: test.runtime, Force: test.force}
 		argsS := fmt.Sprintf("%+v", test)
-
-		req := acomm.NewRequest("systemd-enable")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "systemd-enable",
+			ResponseHook: s.responseHook,
+			Args:         args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.systemd.Enable(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/enable_test.go
+++ b/providers/systemd/enable_test.go
@@ -26,7 +26,7 @@ func (s *systemd) TestEnable() {
 	for _, test := range tests {
 		args := &systemdp.EnableArgs{Name: test.name, Runtime: test.runtime, Force: test.force}
 		argsS := fmt.Sprintf("%+v", test)
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "systemd-enable",
 			ResponseHook: s.responseHook,
 			Args:         args,

--- a/providers/systemd/get_test.go
+++ b/providers/systemd/get_test.go
@@ -21,9 +21,12 @@ func (s *systemd) TestGet() {
 		args := &systemdp.GetArgs{Name: test.name}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req := acomm.NewRequest("systemd-get")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "systemd-get",
+			ResponseHook: s.responseHook,
+			Args:         args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.systemd.Get(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/get_test.go
+++ b/providers/systemd/get_test.go
@@ -21,8 +21,9 @@ func (s *systemd) TestGet() {
 		args := &systemdp.GetArgs{Name: test.name}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req, err := acomm.NewRequest("systemd-exists", "unix:///tmp/foobar", "", args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("systemd-get")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(args), argsS)
 
 		res, streamURL, err := s.systemd.Get(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/get_test.go
+++ b/providers/systemd/get_test.go
@@ -21,7 +21,7 @@ func (s *systemd) TestGet() {
 		args := &systemdp.GetArgs{Name: test.name}
 		argsS := fmt.Sprintf("%+v", test)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "systemd-get",
 			ResponseHook: s.responseHook,
 			Args:         args,

--- a/providers/systemd/remove_test.go
+++ b/providers/systemd/remove_test.go
@@ -32,9 +32,12 @@ func (s *systemd) TestRemove() {
 			s.NoError(f.Close())
 		}
 
-		req := acomm.NewRequest("systemd-remove")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "systemd-remove",
+			ResponseHook: s.responseHook,
+			Args:         args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.systemd.Remove(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/remove_test.go
+++ b/providers/systemd/remove_test.go
@@ -32,8 +32,9 @@ func (s *systemd) TestRemove() {
 			s.NoError(f.Close())
 		}
 
-		req, err := acomm.NewRequest("systemd-remove", "unix:///tmp/foobar", "", args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("systemd-remove")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(args), argsS)
 
 		res, streamURL, err := s.systemd.Remove(req)
 		s.Nil(streamURL, argsS)

--- a/providers/systemd/remove_test.go
+++ b/providers/systemd/remove_test.go
@@ -32,7 +32,7 @@ func (s *systemd) TestRemove() {
 			s.NoError(f.Close())
 		}
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "systemd-remove",
 			ResponseHook: s.responseHook,
 			Args:         args,

--- a/providers/systemd/systemd_test.go
+++ b/providers/systemd/systemd_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,11 +20,12 @@ import (
 
 type systemd struct {
 	suite.Suite
-	dir     string
-	config  *systemdp.Config
-	systemd *systemdp.Systemd
-	flagset *pflag.FlagSet
-	viper   *viper.Viper
+	dir          string
+	config       *systemdp.Config
+	systemd      *systemdp.Systemd
+	flagset      *pflag.FlagSet
+	viper        *viper.Viper
+	responseHook *url.URL
 }
 
 func TestSystemd(t *testing.T) {
@@ -31,6 +33,8 @@ func TestSystemd(t *testing.T) {
 }
 
 func (s *systemd) SetupSuite() {
+	s.responseHook, _ = url.ParseRequestURI("unix:///tmp/foobar")
+
 	dir, err := ioutil.TempDir("", "systemd-provider-test-")
 	s.Require().NoError(err)
 	s.dir = dir

--- a/providers/zfs/clone_test.go
+++ b/providers/zfs/clone_test.go
@@ -36,9 +36,12 @@ func (s *zfs) TestClone() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-clone")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-clone",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Clone(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/clone_test.go
+++ b/providers/zfs/clone_test.go
@@ -36,8 +36,9 @@ func (s *zfs) TestClone() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-clone", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-clone")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Clone(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/clone_test.go
+++ b/providers/zfs/clone_test.go
@@ -36,7 +36,7 @@ func (s *zfs) TestClone() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-clone",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/create_test.go
+++ b/providers/zfs/create_test.go
@@ -41,7 +41,7 @@ func (s *zfs) TestCreate() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-create",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/create_test.go
+++ b/providers/zfs/create_test.go
@@ -41,9 +41,12 @@ func (s *zfs) TestCreate() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-create")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-create",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Create(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/create_test.go
+++ b/providers/zfs/create_test.go
@@ -41,8 +41,9 @@ func (s *zfs) TestCreate() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-create", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-create")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Create(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/destroy_test.go
+++ b/providers/zfs/destroy_test.go
@@ -31,7 +31,7 @@ func (s *zfs) TestDestroy() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-destroy",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/destroy_test.go
+++ b/providers/zfs/destroy_test.go
@@ -31,9 +31,12 @@ func (s *zfs) TestDestroy() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-destroy")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-destroy",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Destroy(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/destroy_test.go
+++ b/providers/zfs/destroy_test.go
@@ -31,8 +31,9 @@ func (s *zfs) TestDestroy() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-destroy", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-destroy")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Destroy(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/exists_test.go
+++ b/providers/zfs/exists_test.go
@@ -27,9 +27,12 @@ func (s *zfs) TestExists() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-exists")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-exists",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Exists(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/exists_test.go
+++ b/providers/zfs/exists_test.go
@@ -27,8 +27,9 @@ func (s *zfs) TestExists() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-exists", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-exists")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Exists(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/exists_test.go
+++ b/providers/zfs/exists_test.go
@@ -27,7 +27,7 @@ func (s *zfs) TestExists() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-exists",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/get_test.go
+++ b/providers/zfs/get_test.go
@@ -26,9 +26,12 @@ func (s *zfs) TestGet() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-get")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-get",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Get(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/get_test.go
+++ b/providers/zfs/get_test.go
@@ -26,7 +26,7 @@ func (s *zfs) TestGet() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-get",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/get_test.go
+++ b/providers/zfs/get_test.go
@@ -26,8 +26,9 @@ func (s *zfs) TestGet() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-get", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-get")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Get(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/holds_test.go
+++ b/providers/zfs/holds_test.go
@@ -26,8 +26,9 @@ func (s *zfs) TestHolds() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-holds", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-holds")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Holds(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/holds_test.go
+++ b/providers/zfs/holds_test.go
@@ -26,7 +26,7 @@ func (s *zfs) TestHolds() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-holds",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/holds_test.go
+++ b/providers/zfs/holds_test.go
@@ -26,9 +26,12 @@ func (s *zfs) TestHolds() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-holds")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-holds",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Holds(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/list_test.go
+++ b/providers/zfs/list_test.go
@@ -30,8 +30,9 @@ func (s *zfs) TestList() {
 	for _, test := range tests {
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-list", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-list")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.List(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/list_test.go
+++ b/providers/zfs/list_test.go
@@ -30,7 +30,7 @@ func (s *zfs) TestList() {
 	for _, test := range tests {
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-list",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/list_test.go
+++ b/providers/zfs/list_test.go
@@ -30,9 +30,12 @@ func (s *zfs) TestList() {
 	for _, test := range tests {
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-list")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-list",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.List(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/mount_test.go
+++ b/providers/zfs/mount_test.go
@@ -26,7 +26,7 @@ func (s *zfs) TestMount() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-mount",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/mount_test.go
+++ b/providers/zfs/mount_test.go
@@ -25,9 +25,9 @@ func (s *zfs) TestMount() {
 			test.args.Name = filepath.Join(s.pool, test.args.Name)
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
-
-		req, err := acomm.NewRequest("zfs-mount", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-mount")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Mount(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/mount_test.go
+++ b/providers/zfs/mount_test.go
@@ -25,9 +25,13 @@ func (s *zfs) TestMount() {
 			test.args.Name = filepath.Join(s.pool, test.args.Name)
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
-		req := acomm.NewRequest("zfs-mount")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-mount",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Mount(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/receive_test.go
+++ b/providers/zfs/receive_test.go
@@ -41,10 +41,13 @@ func (s *zfs) TestReceive() {
 			reqStreamURL = streamURL
 		}
 
-		req := acomm.NewRequest("zfs-receive")
-		req.ResponseHook = s.responseHook
-		req.StreamURL = reqStreamURL
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-receive",
+			ResponseHook: s.responseHook,
+			StreamURL:    reqStreamURL,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, resStreamURL, err := s.zfs.Receive(req)
 		s.Nil(resStreamURL, argsS)

--- a/providers/zfs/receive_test.go
+++ b/providers/zfs/receive_test.go
@@ -41,7 +41,7 @@ func (s *zfs) TestReceive() {
 			reqStreamURL = streamURL
 		}
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-receive",
 			ResponseHook: s.responseHook,
 			StreamURL:    reqStreamURL,

--- a/providers/zfs/receive_test.go
+++ b/providers/zfs/receive_test.go
@@ -34,15 +34,17 @@ func (s *zfs) TestReceive() {
 		}
 		argsS := fmt.Sprintf("%+v, origin: %s", test.args, test.origin)
 
-		reqStreamURL := ""
+		var reqStreamURL *url.URL
 		if test.origin != "" {
 			streamURL, err := s.zfsSendStreamURL(test.origin)
 			s.Require().NoError(err)
-			reqStreamURL = streamURL.String()
+			reqStreamURL = streamURL
 		}
 
-		req, err := acomm.NewRequest("zfs-send", "unix:///tmp/foobar", reqStreamURL, test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-receive")
+		req.ResponseHook = s.responseHook
+		req.StreamURL = reqStreamURL
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, resStreamURL, err := s.zfs.Receive(req)
 		s.Nil(resStreamURL, argsS)

--- a/providers/zfs/rename_test.go
+++ b/providers/zfs/rename_test.go
@@ -30,7 +30,7 @@ func (s *zfs) TestRename() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-rename",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/rename_test.go
+++ b/providers/zfs/rename_test.go
@@ -30,8 +30,9 @@ func (s *zfs) TestRename() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-rename", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-rename")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Rename(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/rename_test.go
+++ b/providers/zfs/rename_test.go
@@ -30,9 +30,12 @@ func (s *zfs) TestRename() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-rename")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-rename",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Rename(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/rollback_test.go
+++ b/providers/zfs/rollback_test.go
@@ -27,9 +27,12 @@ func (s *zfs) TestRollback() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-rollback")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-rollback",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Rollback(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/rollback_test.go
+++ b/providers/zfs/rollback_test.go
@@ -27,7 +27,7 @@ func (s *zfs) TestRollback() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-rollback",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/rollback_test.go
+++ b/providers/zfs/rollback_test.go
@@ -27,8 +27,9 @@ func (s *zfs) TestRollback() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-rollback", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-rollback")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Rollback(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/send_test.go
+++ b/providers/zfs/send_test.go
@@ -28,9 +28,12 @@ func (s *zfs) TestSend() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-send")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-send",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Send(req)
 		if test.err == "" {

--- a/providers/zfs/send_test.go
+++ b/providers/zfs/send_test.go
@@ -28,7 +28,7 @@ func (s *zfs) TestSend() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-send",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/send_test.go
+++ b/providers/zfs/send_test.go
@@ -28,8 +28,9 @@ func (s *zfs) TestSend() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-send", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-send")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Send(req)
 		if test.err == "" {

--- a/providers/zfs/snapshot_test.go
+++ b/providers/zfs/snapshot_test.go
@@ -27,8 +27,9 @@ func (s *zfs) TestSnapshot() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-snapshot", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-snapshot")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Snapshot(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/snapshot_test.go
+++ b/providers/zfs/snapshot_test.go
@@ -27,7 +27,7 @@ func (s *zfs) TestSnapshot() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-snapshot",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/snapshot_test.go
+++ b/providers/zfs/snapshot_test.go
@@ -27,9 +27,12 @@ func (s *zfs) TestSnapshot() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-snapshot")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-snapshot",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Snapshot(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/unmount_test.go
+++ b/providers/zfs/unmount_test.go
@@ -26,9 +26,12 @@ func (s *zfs) TestUnmount() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req := acomm.NewRequest("zfs-unmount")
-		req.ResponseHook = s.responseHook
-		s.Require().NoError(req.SetArgs(test.args), argsS)
+		req, err := acomm.NewRequest(&acomm.RequestOptions{
+			Task:         "zfs-unmount",
+			ResponseHook: s.responseHook,
+			Args:         test.args,
+		})
+		s.Require().NoError(err, argsS)
 
 		res, streamURL, err := s.zfs.Unmount(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/unmount_test.go
+++ b/providers/zfs/unmount_test.go
@@ -26,7 +26,7 @@ func (s *zfs) TestUnmount() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest(&acomm.RequestOptions{
+		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:         "zfs-unmount",
 			ResponseHook: s.responseHook,
 			Args:         test.args,

--- a/providers/zfs/unmount_test.go
+++ b/providers/zfs/unmount_test.go
@@ -26,8 +26,9 @@ func (s *zfs) TestUnmount() {
 		}
 		argsS := fmt.Sprintf("%+v", test.args)
 
-		req, err := acomm.NewRequest("zfs-unmount", "unix:///tmp/foobar", "", test.args, nil, nil)
-		s.Require().NoError(err, argsS)
+		req := acomm.NewRequest("zfs-unmount")
+		req.ResponseHook = s.responseHook
+		s.Require().NoError(req.SetArgs(test.args), argsS)
 
 		res, streamURL, err := s.zfs.Unmount(req)
 		s.Empty(streamURL, argsS)

--- a/providers/zfs/zfs_test.go
+++ b/providers/zfs/zfs_test.go
@@ -3,6 +3,7 @@ package zfs_test
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,12 +37,13 @@ var (
 
 type zfs struct {
 	suite.Suite
-	pool    string
-	files   []string
-	dir     string
-	config  *provider.Config
-	tracker *acomm.Tracker
-	zfs     *zfsp.ZFS
+	pool         string
+	files        []string
+	dir          string
+	config       *provider.Config
+	tracker      *acomm.Tracker
+	zfs          *zfsp.ZFS
+	responseHook *url.URL
 }
 
 func TestZFS(t *testing.T) {
@@ -141,6 +143,7 @@ func unhold(tag, snapshot string) error {
 }
 
 func (s *zfs) SetupSuite() {
+	s.responseHook, _ = url.ParseRequestURI("unix:///tmp/foobar")
 	dir, err := ioutil.TempDir("", "zfs-provider-test-")
 	s.Require().NoError(err)
 	s.dir = dir

--- a/providers/zfs/zfs_test.go
+++ b/providers/zfs/zfs_test.go
@@ -160,7 +160,7 @@ func (s *zfs) SetupSuite() {
 	s.Require().NoError(config.SetupLogging())
 	s.config = config
 
-	tracker, err := acomm.NewTracker(filepath.Join(s.dir, "tracker.sock"), nil, 5*time.Second)
+	tracker, err := acomm.NewTracker(filepath.Join(s.dir, "tracker.sock"), nil, nil, 5*time.Second)
 	s.Require().NoError(err)
 	s.Require().NoError(tracker.Start())
 	s.tracker = tracker

--- a/zfs/nv/README.md
+++ b/zfs/nv/README.md
@@ -67,7 +67,7 @@ NativeEncoder is an Encoder for native encoding.
 ```go
 func NewNativeEncoder(w io.Writer) *NativeEncoder
 ```
-NewNativeEncoder creates a new nativeEncoder.
+NewNativeEncoder creates a new NativeEncoder.
 
 #### func (NativeEncoder) Encode
 


### PR DESCRIPTION
## Issues affected/resolved

(See https://github.com/blog/1506-closing-issues-via-pull-requests)
Resolves #142
## Description:

Adds ability for providers to make requests serviced by other coordinators, with the requests and responses proxied through the providers' coordinator. For example, given a setup where `Coordinator1<->ProviderA` and `Coordinator2<->ProviderB`, this will allow `ProviderA` to use `Provider.TaskZ`, where the request and response will be proxied through `Coordinator1<->Coordinator2`. `ProviderA` never talks to anything other than `Coordinator1` and `ProviderB` never talks to anything other than `Coordinator2`.

External requests are controlled via the `acomm.Request.TaskURL` property. Coordinators will proxy based on whether that is present or not.

Additionally, cleaned up the function signature for creating a new `acomm.Request` as it was getting quite long and disbaled tcp keepalives for coordinators to avoid hanging on shutdown. We'll revisit graceful shutdowns in a separate issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/144)

<!-- Reviewable:end -->
