### PR TITLE
Stats pusher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cmd/coordinator/coordinator
 cmd/kv-provider/kv-provider
 cmd/metrics-provider/metrics-provider
 cmd/nvprint/nvprint
+cmd/statspusher/statspusher
 cmd/systemd-provider/systemd-provider
 cmd/zfs-provider/zfs-provider
 cmd/zfs/zfs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Compiled cmds
+cmd/clusterconfig-provider/clusterconfig-provider
 cmd/coordinator-cli/coordinator-cli
 cmd/coordinator/coordinator
 cmd/kv-provider/kv-provider
@@ -8,7 +9,6 @@ cmd/statspusher/statspusher
 cmd/systemd-provider/systemd-provider
 cmd/zfs-provider/zfs-provider
 cmd/zfs/zfs
-cmd/clusterconfig-provider/clusterconfig-provider
 
 # Temporary files
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cmd/statspusher/statspusher
 cmd/systemd-provider/systemd-provider
 cmd/zfs-provider/zfs-provider
 cmd/zfs/zfs
+cmd/clusterconfig-provider/clusterconfig-provider
 
 # Temporary files
 *.swp

--- a/cmd/statspusher/README.md
+++ b/cmd/statspusher/README.md
@@ -1,0 +1,9 @@
+# statspusher
+
+[![statspusher](https://godoc.org/github.com/cerana/cerana/cmd/statspusher?status.svg)](https://godoc.org/github.com/cerana/cerana/cmd/statspusher)
+
+
+
+
+--
+*Generated with [godocdown](https://github.com/robertkrimen/godocdown)*

--- a/cmd/statspusher/README.md
+++ b/cmd/statspusher/README.md
@@ -2,7 +2,19 @@
 
 [![statspusher](https://godoc.org/github.com/cerana/cerana/cmd/statspusher?status.svg)](https://godoc.org/github.com/cerana/cerana/cmd/statspusher)
 
+Usage:
 
+    $ statspusher -h
+    Usage of statspusher
+    -b, --bundleTTL uint          default timeout for requests made (seconds)
+    -c, --configFile string       path to config file
+    -u, --coordinatorURL string   url of coordinator for information retrieval
+    -d, --datasetTTL uint         default timeout for requests made (seconds)
+    -e, --heartbeatURL string     url of coordinator for the heartbeat registering
+    -l, --logLevel string         log level: debug/info/warn/error/fatal/panic (default "warning")
+    -n, --nodeTTL uint            default timeout for requests made  (seconds)
+    -r, --requestTimeout uint     default timeout for requests made (seconds)
+    Note: Flags can be used in either fooBar or foo[_-.]bar form.
 
 
 --

--- a/cmd/statspusher/bundle.go
+++ b/cmd/statspusher/bundle.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/providers/clusterconf"
+	"github.com/cerana/cerana/providers/systemd"
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/pborman/uuid"
+	"github.com/shirou/gopsutil/host"
+)
+
+func (s *statsPusher) bundleHeartbeats() error {
+	serial, err := s.getSerial()
+	if err != nil {
+		return err
+	}
+	ip, err := s.getIP()
+	if err != nil {
+		return err
+	}
+	bundles, err := s.getBundles()
+	if err != nil {
+		return err
+	}
+	healthy, err := s.runHealthChecks(bundles)
+	if err != nil {
+		//log
+	}
+	return s.sendBundleHeartbeats(healthy, serial, ip)
+}
+
+func (s *statsPusher) getBundles() ([]*clusterconf.Bundle, error) {
+	requests := make(map[string]*acomm.Request)
+	localReq, err := acomm.NewRequest(acomm.RequestOptions{Task: "service-bundles"})
+	if err != nil {
+		return nil, err
+	}
+	requests["local"] = localReq
+	knownReq, err := acomm.NewRequest(acomm.RequestOptions{
+		Task:    "systemd-list",
+		TaskURL: s.config.heartbeatURL(),
+	})
+	requests["known"] = knownReq
+
+	multiRequest := acomm.NewMultiRequest(s.tracker, s.config.requestTimeout())
+	for name, req := range requests {
+		if err := multiRequest.AddRequest(name, req); err != nil {
+			break
+		}
+		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+			multiRequest.RemoveRequest(req)
+			break
+		}
+	}
+
+	responses := multiRequest.Responses()
+
+	var localUnits systemd.ListResult
+	if err := responses["local"].UnmarshalResult(&localUnits); err != nil {
+		return nil, err
+	}
+	localBundles := extractBundles(localUnits.Units)
+	var knownBundles clusterconf.BundleListResult
+	if err := responses["known"].UnmarshalResult(&knownBundles); err != nil {
+		return nil, err
+	}
+
+	bundles := make([]*clusterconf.Bundle, len(localBundles))
+	for _, local := range localBundles {
+		for _, known := range knownBundles.Bundles {
+			if known.ID == local {
+				bundles = append(bundles, known)
+				break
+			}
+		}
+	}
+
+	return bundles, nil
+}
+
+func (s *statsPusher) getSerial() (string, error) {
+	doneChan := make(chan *acomm.Response, 1)
+	rh := func(_ *acomm.Request, resp *acomm.Response) {
+		doneChan <- resp
+	}
+	req, err := acomm.NewRequest(acomm.RequestOptions{
+		Task:           "metrics-host",
+		ResponseHook:   s.tracker.URL(),
+		SuccessHandler: rh,
+		ErrorHandler:   rh,
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		return "", err
+	}
+
+	resp := <-doneChan
+	if resp.Error != nil {
+		return "", resp.Error
+	}
+
+	var data host.InfoStat
+	if err := resp.UnmarshalResult(&data); err != nil {
+		return "", err
+	}
+
+	return data.Hostname, nil
+}
+
+func (s *statsPusher) sendBundleHeartbeats(bundles []int, serial string, ip net.IP) error {
+	var errored bool
+
+	multiRequest := acomm.NewMultiRequest(s.tracker, s.config.requestTimeout())
+	for _, bundle := range bundles {
+		req, err := acomm.NewRequest(acomm.RequestOptions{
+			Task:    "bundle-heartbeat",
+			TaskURL: s.config.heartbeatURL(),
+			Args: clusterconf.BundleHeartbeatArgs{
+				ID:     bundle,
+				Serial: serial,
+				IP:     ip,
+			},
+		})
+		if err != nil {
+			errored = true
+			continue
+		}
+		if err := multiRequest.AddRequest(strconv.Itoa(bundle), req); err != nil {
+			errored = true
+			continue
+		}
+		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+			multiRequest.RemoveRequest(req)
+			errored = true
+			continue
+		}
+	}
+	responses := multiRequest.Responses()
+	for _, resp := range responses {
+		if resp.Error != nil {
+			errored = true
+			break
+		}
+	}
+
+	if errored {
+		return errors.New("one or more bundle heartbeats unsuccessful")
+	}
+	return nil
+}
+
+// TODO: Make this actually run health checks
+func (s *statsPusher) runHealthChecks(bundles []*clusterconf.Bundle) ([]int, error) {
+	healthy := make([]int, len(bundles))
+	for i, bundle := range bundles {
+		healthy[i] = bundle.ID
+	}
+	return healthy, nil
+}
+
+func extractBundles(units []dbus.UnitStatus) []int {
+	dedupe := make(map[int]bool)
+	for _, unit := range units {
+		// bundleID:serviceID
+		parts := strings.Split(unit.Name, ":")
+		bundleID, err := strconv.Atoi(parts[0])
+		if err != nil && len(parts) == 2 && uuid.Parse(parts[1]) != nil {
+			dedupe[bundleID] = true
+		}
+	}
+	ids := make([]int, 0, len(dedupe))
+	for id := range dedupe {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/cmd/statspusher/bundle.go
+++ b/cmd/statspusher/bundle.go
@@ -162,6 +162,7 @@ func (s *statsPusher) sendBundleHeartbeats(bundles []uint64, serial string, ip n
 }
 
 // TODO: Make this actually run health checks
+// Issue: #189
 func (s *statsPusher) runHealthChecks(bundles []*clusterconf.Bundle) ([]uint64, error) {
 	healthy := make([]uint64, len(bundles))
 	for i, bundle := range bundles {

--- a/cmd/statspusher/bundle_test.go
+++ b/cmd/statspusher/bundle_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/cerana/cerana/providers/clusterconf"
+	"github.com/coreos/go-systemd/dbus"
+	"github.com/pborman/uuid"
+)
+
+func (s *StatsPusher) TestGetSerial() {
+	serial, err := s.statsPusher.getSerial()
+	if !s.NoError(err) {
+		return
+	}
+	s.Equal(s.metrics.Data.Host.Hostname, serial)
+}
+
+func (s *StatsPusher) extractBundles() {
+
+}
+
+func (s *StatsPusher) TestGetBundles() {
+	tests := []struct {
+		desc   string
+		known  []int
+		local  []int
+		result []int
+	}{
+		{"empty", []int{}, []int{}, []int{}},
+		{"known only", []int{123}, []int{}, []int{}},
+		{"local only", []int{}, []int{123}, []int{}},
+		{"both, single", []int{123}, []int{123}, []int{123}},
+		{"extra local", []int{123}, []int{123, 456}, []int{123}},
+		{"extra known", []int{123, 456}, []int{123}, []int{123}},
+		{"both, multiple", []int{123, 456}, []int{123, 456}, []int{123, 456}},
+	}
+
+	for _, test := range tests {
+		s.systemd.Data.Statuses = make(map[string]dbus.UnitStatus)
+		for _, bundle := range test.local {
+			for i := 0; i < 3; i++ {
+				serviceName := fmt.Sprintf("%d:%s", bundle, uuid.New())
+				s.systemd.Data.Statuses[serviceName] = dbus.UnitStatus{Name: serviceName}
+			}
+		}
+		s.clusterConf.Data.Bundles = make(map[int]*clusterconf.Bundle)
+		for _, id := range test.known {
+			s.clusterConf.Data.Bundles[id] = &clusterconf.Bundle{BundleConf: &clusterconf.BundleConf{ID: id}}
+		}
+		bundles, err := s.statsPusher.getBundles()
+		if !s.NoError(err, test.desc) {
+			continue
+		}
+		bundleIDs := make([]int, 0, len(bundles))
+		for _, bundle := range bundles {
+			bundleIDs = append(bundleIDs, bundle.ID)
+		}
+		sort.Ints(test.result)
+		sort.Ints(bundleIDs)
+		s.Equal(test.result, bundleIDs, test.desc)
+	}
+}
+
+func (s *StatsPusher) TestRunHealthChecks() {
+	// TODO: Write proper tests when this is done
+	bundles := []*clusterconf.Bundle{
+		&clusterconf.Bundle{BundleConf: &clusterconf.BundleConf{ID: 123}},
+	}
+
+	healthy, err := s.statsPusher.runHealthChecks(bundles)
+	s.NoError(err)
+	s.Len(healthy, len(bundles))
+}
+
+func (s *StatsPusher) TestSendBundleHeartbeats() {
+	serial := "foobar"
+	ip := net.ParseIP("123.123.123.123")
+	bundles := []int{123, 456}
+	for _, id := range bundles {
+		s.clusterConf.Data.Bundles[id] = &clusterconf.Bundle{BundleConf: &clusterconf.BundleConf{ID: id}}
+	}
+	s.NoError(s.statsPusher.sendBundleHeartbeats(bundles, serial, ip))
+	for _, id := range bundles {
+		s.Equal(ip, s.clusterConf.Data.Bundles[id].Nodes[serial])
+	}
+}

--- a/cmd/statspusher/bundle_test.go
+++ b/cmd/statspusher/bundle_test.go
@@ -67,7 +67,7 @@ func (s *StatsPusher) TestGetBundles() {
 func (s *StatsPusher) TestRunHealthChecks() {
 	// TODO: Write proper tests when this is done
 	bundles := []*clusterconf.Bundle{
-		&clusterconf.Bundle{BundleConf: &clusterconf.BundleConf{ID: 123}},
+		{BundleConf: &clusterconf.BundleConf{ID: 123}},
 	}
 
 	healthy, err := s.statsPusher.runHealthChecks(bundles)

--- a/cmd/statspusher/config.go
+++ b/cmd/statspusher/config.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/cerana/cerana/pkg/logrusx"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+var (
+	flagSep     = regexp.MustCompile(`[\s._-]+`)
+	specialCaps = regexp.MustCompile("(?i)^(url|ttl|cpu|ip|id)$")
+)
+
+type config struct {
+	viper   *viper.Viper
+	flagSet *pflag.FlagSet
+}
+
+// ConfigData defines the structure of the config data (e.g. in the config file)
+type ConfigData struct {
+	CoordinatorURL string `json:"coordinatorURL"`
+	LogLevel       string `json:"logLevel"`
+	// Timeout and TTL values are in seconds
+	RequestTimeout uint64 `json:"requestTimeout"`
+	DatasetTTL     uint64 `json:"datasetTTL"`
+	BundleTTL      uint64 `json:"bundleTTL"`
+	NodeTTL        uint64 `json:"nodeTTL"`
+}
+
+func newConfig(flagSet *pflag.FlagSet, v *viper.Viper) *config {
+	if flagSet == nil {
+		flagSet = pflag.CommandLine
+	}
+
+	if v == nil {
+		v = viper.New()
+	}
+
+	// Set normalization function before adding any flags
+	flagSet.SetNormalizeFunc(canonicalFlagName)
+
+	// Update Usage (--help output) to indicate flag
+	pflag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		pflag.PrintDefaults()
+		fmt.Fprintln(os.Stderr, "Note: Flags can be used in either fooBar or foo[_-.]bar form.")
+	}
+
+	flagSet.StringP("config-file", "c", "", "path to config file")
+	flagSet.StringP("coordinator-url", "u", "", "url of coordinator for making requests")
+	flagSet.StringP("log-level", "l", "warning", "log level: debug/info/warn/error/fatal/panic")
+	flagSet.Uint64P("request-timeout", "r", 0, "default timeout for requests made (seconds)")
+	flagSet.Uint64P("dataset-ttl", "d", 0, "default timeout for requests made (seconds)")
+	flagSet.Uint64P("bundle-ttl", "b", 0, "default timeout for requests made (seconds)")
+	flagSet.Uint64P("node-ttl", "n", 0, "default timeout for requests made  (seconds)")
+
+	return &config{
+		viper:   v,
+		flagSet: flagSet,
+	}
+}
+
+// canonicalFlagName translates flag names to camelCase using whitespace,
+// periods, underscores, and dashes as word boundaries. All-caps words are
+// preserved.
+func canonicalFlagName(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	// Standardize separators to a single space and trim leading/trailing spaces
+	name = strings.TrimSpace(flagSep.ReplaceAllString(name, " "))
+
+	// Convert to title case (lower case with leading caps, preserved all caps)
+	name = strings.Title(name)
+
+	// Some words should always be all caps or all lower case (e.g. TTL)
+	nameParts := strings.Split(name, " ")
+	for i, part := range nameParts {
+		caseFn := strings.ToUpper
+		if i == 0 {
+			caseFn = strings.ToLower
+		}
+
+		nameParts[i] = specialCaps.ReplaceAllStringFunc(part, caseFn)
+	}
+
+	// Split on space and examine the first part
+	first := nameParts[0]
+	if utf8.RuneCountInString(first) == 1 || first != strings.ToUpper(first) {
+		// Lowercase the first letter if it is not an all-caps word
+		r, n := utf8.DecodeRuneInString(first)
+		nameParts[0] = string(unicode.ToLower(r)) + first[n:]
+	}
+
+	return pflag.NormalizedName(strings.Join(nameParts, ""))
+}
+
+func (c *config) coordinatorURL() *url.URL {
+	// Error checking has been done during validation
+	u, _ := url.ParseRequestURI(c.viper.GetString("coordinatorURL"))
+	return u
+}
+
+func (c *config) requestTimeout() time.Duration {
+	return time.Second * time.Duration(c.viper.GetInt("requestTimeout"))
+}
+
+func (c *config) datasetTTL() time.Duration {
+	return c.getTTL("datasetTTL")
+}
+
+func (c *config) nodeTTL() time.Duration {
+	return c.getTTL("nodeTTL")
+}
+
+func (c *config) bundleTTL() time.Duration {
+	return c.getTTL("datasetTTL")
+}
+
+func (c *config) getTTL(key string) time.Duration {
+	return time.Second * time.Duration(c.viper.GetInt(key))
+}
+
+func (c *config) setLogging() error {
+	logLevel := c.viper.GetString("logLevel")
+	if err := logrusx.SetLevel(logLevel); err != nil {
+		logrus.WithFields(logrus.Fields{
+			"error": err,
+			"level": logLevel,
+		}).Error("failed to set up logging")
+		return err
+	}
+	return nil
+}
+
+func (c *config) validate() error {
+	if c.datasetTTL() <= 0 {
+		return errors.New("dataset ttl must be > 0")
+	}
+	if c.bundleTTL() <= 0 {
+		return errors.New("bundle ttl must be > 0")
+	}
+	if c.nodeTTL() <= 0 {
+		return errors.New("node ttl must be > 0")
+	}
+	if c.requestTimeout() <= 0 {
+		return errors.New("request timeout must be > 0")
+	}
+
+	if _, err := url.ParseRequestURI(c.viper.GetString("coordinator url")); err != nil {
+		logrus.WithFields(logrus.Fields{
+			"coordinatorURL": c.viper.GetString("coordinatorURL"),
+			"error":          err,
+		}).Error("invalid config")
+		return err
+	}
+
+	return nil
+}

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/suite"
+)
+
+type StatsPusher struct {
+	suite.Suite
+}
+
+func TestStatsPusher(t *testing.T) {
+	suite.Run(t, new(StatsPusher))
+}
+
+func (s *StatsPusher) TestCanonicalFlagName() {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{"foo bar", "fooBar"},
+		{"foo	bar", "fooBar"},
+		{"foo.bar", "fooBar"},
+		{"foo_bar", "fooBar"},
+		{"foo-bar", "fooBar"},
+		{"foo.-_bar", "fooBar"},
+		{"Foo_bar", "fooBar"},
+		{"foo_bar.baz bang", "fooBarBazBang"},
+		{"Foo_bar", "fooBar"},
+		{"foo_BAR", "fooBAR"},
+		{"foo_cpu", "fooCPU"},
+		{"foo_ttl", "fooTTL"},
+		{"foo_cpu", "fooCPU"},
+		{"foo_url", "fooURL"},
+		{"foo_ip", "fooIP"},
+		{"foo_id", "fooID"},
+		{"FOO_bar", "FOOBar"},
+		{"Cpu_bar", "cpuBar"},
+		{"id_bar", "idBar"},
+		{"CPU_bar", "cpuBar"},
+	}
+
+	for _, test := range tests {
+		s.Equal(test.output, string(canonicalFlagName(pflag.CommandLine, test.input)), test.input)
+	}
+}

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -7,49 +7,13 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/suite"
 )
-
-type StatsPusher struct {
-	suite.Suite
-	config     *config
-	configData *ConfigData
-	configFile *os.File
-}
-
-func TestStatsPusher(t *testing.T) {
-	suite.Run(t, new(StatsPusher))
-}
-
-func (s *StatsPusher) SetupTest() {
-	logrus.SetLevel(logrus.FatalLevel)
-
-	s.configData = &ConfigData{
-		CoordinatorURL: "unix:///tmp/foobar",
-		HeartbeatURL:   "unix:///tmp/foobar",
-		LogLevel:       "fatal",
-		RequestTimeout: 5,
-		DatasetTTL:     4,
-		BundleTTL:      3,
-		NodeTTL:        2,
-	}
-
-	var err error
-	s.config, _, _, s.configFile, err = newTestConfig(false, true, s.configData)
-	s.Require().NoError(err, "failed to create config")
-	s.Require().NoError(s.config.loadConfig(), "failed to load config")
-}
-
-func (s *StatsPusher) TearDownTest() {
-	_ = os.Remove(s.configFile.Name())
-}
 
 func (s *StatsPusher) TestCanonicalFlagName() {
 	tests := []struct {

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -1,18 +1,53 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/Sirupsen/logrus"
+	"github.com/pborman/uuid"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 )
 
 type StatsPusher struct {
 	suite.Suite
+	config     *config
+	configData *ConfigData
+	configFile *os.File
 }
 
 func TestStatsPusher(t *testing.T) {
 	suite.Run(t, new(StatsPusher))
+}
+
+func (s *StatsPusher) SetupTest() {
+	logrus.SetLevel(logrus.FatalLevel)
+
+	s.configData = &ConfigData{
+		CoordinatorURL: "unix:///tmp/foobar",
+		LogLevel:       "fatal",
+		RequestTimeout: 5,
+		DatasetTTL:     4,
+		BundleTTL:      3,
+		NodeTTL:        2,
+	}
+
+	var err error
+	s.config, _, _, s.configFile, err = newTestConfig(false, true, s.configData)
+	s.Require().NoError(err, "failed to create config")
+	s.Require().NoError(s.config.loadConfig(), "failed to load config")
+}
+
+func (s *StatsPusher) TearDownTest() {
+	_ = os.Remove(s.configFile.Name())
 }
 
 func (s *StatsPusher) TestCanonicalFlagName() {
@@ -45,4 +80,177 @@ func (s *StatsPusher) TestCanonicalFlagName() {
 	for _, test := range tests {
 		s.Equal(test.output, string(canonicalFlagName(pflag.CommandLine, test.input)), test.input)
 	}
+}
+
+func (s *StatsPusher) TestNewConfig() {
+	tests := []struct {
+		description string
+		flagSet     *pflag.FlagSet
+		viper       *viper.Viper
+	}{
+		{"defaults", nil, nil},
+		{"specified flagset", pflag.NewFlagSet(uuid.New(), pflag.ExitOnError), nil},
+		{"specified viper", nil, viper.New()},
+		{"specified both", pflag.NewFlagSet(uuid.New(), pflag.ExitOnError), viper.New()},
+	}
+
+	for _, test := range tests {
+		// Reset the default CommandLine flags between runs
+		pflag.CommandLine = pflag.NewFlagSet(uuid.New(), pflag.ExitOnError)
+		s.NotNil(newConfig(test.flagSet, test.viper), test.description)
+	}
+}
+
+func (s *StatsPusher) TestLoadConfig() {
+	tests := []struct {
+		description string
+		setFlags    bool
+		writeConfig bool
+		expectedErr bool
+	}{
+		{"nothing set", false, false, true},
+		{"flags only", true, false, false},
+		{"config file", false, true, false},
+		{"flags and config", true, true, false},
+	}
+
+	for _, test := range tests {
+		config, _, _, configFile, err := newTestConfig(test.setFlags, test.writeConfig, s.configData)
+		if configFile != nil {
+			defer func() { _ = os.Remove(configFile.Name()) }()
+		}
+		if !s.NoError(err, test.description) {
+			continue
+		}
+
+		err = config.loadConfig()
+		if test.expectedErr {
+			s.Error(err, test.description)
+		} else {
+			s.NoError(err, test.description)
+		}
+	}
+}
+
+func (s *StatsPusher) TestSetupLogging() {
+	s.NoError(s.config.setupLogging(), "failed to setup logging")
+	s.Equal(s.configData.LogLevel, logrus.GetLevel().String())
+}
+
+func (s *StatsPusher) TestValidate() {
+	tests := []struct {
+		description    string
+		coordinatorURL string
+		requestTimeout uint
+		datasetTTL     uint
+		bundleTTL      uint
+		nodeTTL        uint
+		expectedErr    string
+	}{
+		{"valid", "unix:///tmp/foobar", 5, 4, 3, 2, ""},
+		{"missing coord", "", 5, 4, 3, 2, "missing coordinator url"},
+		{"invalud coord", "asdf", 5, 4, 3, 2, "invalid coordinator url"},
+		{"invalid request timeout", "unix:///tmp/foobar", 0, 4, 3, 2, "request timeout must be > 0"},
+		{"invalid dataset ttl", "unix:///tmp/foobar", 5, 0, 3, 2, "dataset ttl must be > 0"},
+		{"invalid bundle ttl", "unix:///tmp/foobar", 5, 4, 0, 2, "bundle ttl must be > 0"},
+		{"invalid node ttl", "unix:///tmp/foobar", 5, 4, 3, 0, "node ttl must be > 0"},
+	}
+
+	for _, test := range tests {
+		configData := &ConfigData{
+			CoordinatorURL: test.coordinatorURL,
+			RequestTimeout: test.requestTimeout,
+			DatasetTTL:     test.datasetTTL,
+			BundleTTL:      test.bundleTTL,
+			NodeTTL:        test.nodeTTL,
+		}
+
+		config, fs, v, _, err := newTestConfig(true, false, configData)
+		if !s.NoError(err, test.description) {
+			continue
+		}
+		// Bind here to avoid the need for Load
+		s.Require().NoError(v.BindPFlags(fs), test.description)
+
+		err = config.validate()
+		if test.expectedErr != "" {
+			s.EqualError(err, test.expectedErr, test.description)
+		} else {
+			s.NoError(err, test.description)
+		}
+	}
+}
+
+func (s *StatsPusher) TestCoordinatorURL() {
+	u, err := url.ParseRequestURI(s.configData.CoordinatorURL)
+	s.Require().NoError(err)
+	s.Equal(u, s.config.coordinatorURL())
+}
+
+func (s *StatsPusher) TestRequestTimeout() {
+	s.EqualValues(s.configData.RequestTimeout, s.config.requestTimeout()/time.Second)
+}
+
+func (s *StatsPusher) TestDatasetTTL() {
+	s.EqualValues(s.configData.DatasetTTL, s.config.datasetTTL()/time.Second)
+}
+
+func (s *StatsPusher) TestBundleTTL() {
+	s.EqualValues(s.configData.BundleTTL, s.config.bundleTTL()/time.Second)
+}
+
+func (s *StatsPusher) TestNodeTTL() {
+	s.EqualValues(s.configData.NodeTTL, s.config.nodeTTL()/time.Second)
+}
+
+func newTestConfig(setFlags, writeConfig bool, configData *ConfigData) (*config, *pflag.FlagSet, *viper.Viper, *os.File, error) {
+	fs := pflag.NewFlagSet(uuid.New(), pflag.ExitOnError)
+	v := viper.New()
+	v.SetConfigType("json")
+	config := newConfig(fs, v)
+	if config == nil {
+		return nil, nil, nil, nil, errors.New("failed to return a config")
+	}
+
+	var configFile *os.File
+	if writeConfig {
+		var err error
+		configFile, err = ioutil.TempFile("", "statspusherTest-")
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		defer func() { _ = configFile.Close() }()
+
+		configJSON, _ := json.Marshal(configData)
+		if _, err := configFile.Write(configJSON); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+
+		if err := fs.Set("configFile", configFile.Name()); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+	}
+
+	if setFlags {
+		if err := fs.Set("coordinatorURL", configData.CoordinatorURL); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+		if err := fs.Set("logLevel", configData.LogLevel); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+		if err := fs.Set("requestTimeout", strconv.FormatUint(uint64(configData.RequestTimeout), 10)); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+		if err := fs.Set("datasetTTL", strconv.FormatUint(uint64(configData.DatasetTTL), 10)); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+		if err := fs.Set("bundleTTL", strconv.FormatUint(uint64(configData.BundleTTL), 10)); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+		if err := fs.Set("nodeTTL", strconv.FormatUint(uint64(configData.NodeTTL), 10)); err != nil {
+			return nil, nil, nil, configFile, err
+		}
+	}
+
+	return config, fs, v, configFile, nil
 }

--- a/cmd/statspusher/dataset.go
+++ b/cmd/statspusher/dataset.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/providers/metrics"
+	"github.com/mistifyio/go-zfs"
+)
+
+func (s *statsPusher) datasetHeartbeats() error {
+	datasets, err := s.getDatasets()
+	if err != nil {
+		return err
+	}
+	ip, err := s.getIP()
+	if err != nil {
+		return err
+	}
+
+	return s.sendDatasetHeartbeats(datasets, ip)
+}
+
+func (s *statsPusher) getDatasets() ([]string, error) {
+	datasets := []string{}
+
+	requests := make(map[string]*acomm.Request)
+	localReq, err := acomm.NewRequest(acomm.RequestOptions{Task: "zfs-list"})
+	if err != nil {
+		return datasets, err
+	}
+	requests["local"] = localReq
+	knownReq, err := acomm.NewRequest(acomm.RequestOptions{
+		Task:         "get-datasets",
+		HeartbeatURL: s.config.heartbeatURL(),
+	})
+	if err != nil {
+		return datasets, err
+	}
+	requests["known"] = knownReq
+
+	multiRequest := acomm.NewMultiRequest(s.tracker, s.config.requestTimeout())
+	for name, req := range requests {
+		if err := multiRequest.AddRequest(name, req); err != nil {
+			break
+		}
+		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+			multiRequest.RemoveRequest(req)
+			break
+		}
+	}
+
+	responses := multiRequest.Responses()
+	for name := range requests {
+		resp, ok := responses[name]
+		if !ok {
+			return datasets, fmt.Errorf("failed to send request: %s", name)
+		}
+		if resp.Error != nil {
+			return datasets, fmt.Errorf("request failed: %s: %s", name, resp.Error)
+		}
+		if err := resp.UnmarshalResult(tasks[name]); err != nil {
+			return datasets, err
+		}
+	}
+
+	localDatasets := responses["local"].([]*zfs.Dataset)
+	knownDatasets := responses["known"].([]*zfs.Dataset)
+	datasets = make([]string, 0, len(localDatasets))
+	for _, known := range localDatasets {
+		for _, local := range knownDatasets {
+			if known.ID == local.Name {
+				datasets = append(datasets, local.Name)
+				break
+			}
+		}
+	}
+	return datasets, nil
+}
+
+func (s *statsPusher) getIP() (*net.IP, error) {
+	doneChan := make(chan *acomm.Response, 1)
+	rh := func(_ *acomm.Request, resp *acomm.Response) {
+		doneChan <- resp
+	}
+	req, err := acomm.NewRequest(acomm.RequestOptions{
+		Task:           "metrics-network",
+		SuccessHandler: rh,
+		ErrorHandler:   rh,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Send(s.config.coordinatorURL()); err != nil {
+		return nil, err
+	}
+
+	resp := <-doneChan
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	var data metrics.NetworkResult
+	if err := resp.UnmarshalResult(&data); err != nil {
+		return nil, err
+	}
+	for _, iface := range data.Interfaces {
+		for _, ifaceAddr := range iface.Addrs {
+			ip := net.ParseIP(ifaceAddr.Addr)
+			if ip != nil && !ip.IsLoopback() {
+				return ip, nil
+			}
+		}
+	}
+	return nil, errors.New("no suitable IP found")
+}
+
+func (s *statsPusher) sendDatasetHeartbeats(datasets []*zfs.Dataset, ip *net.IP) error {
+	var errored bool
+
+	multiRequest := acomm.NewMultirequest(s.tracker, s.config.requestTimeout())
+	for _, dataset := range datasets {
+		req, err := acomm.NewRequest(acomm.RequestOptions{
+			Task:    "dataset-heartbeat",
+			TaskURL: s.config.heartbeatURL(),
+			Args: DatasetHeartbeatArgs{
+				ID: dataset.Name,
+				IP: ip,
+			},
+		})
+		if err != nil {
+			errored = true
+			continue
+		}
+		if err := multirequest.AddRequest(dataset.Name, req); err != nil {
+			errored = true
+			continue
+		}
+		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+			multiRequest.RemoveRequest(req)
+			errored = true
+			continue
+		}
+	}
+	responses := multiRequest.Responses()
+	for name, resp := range responses {
+		if resp.Error != nil {
+			errored = true
+		}
+	}
+
+	if errored {
+		return errors.New("one or more dataset heartbeats unsuccessful")
+	}
+	return nil
+}

--- a/cmd/statspusher/dataset_test.go
+++ b/cmd/statspusher/dataset_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cerana/cerana/providers/clusterconf"
+	zfsp "github.com/cerana/cerana/providers/zfs"
+	"github.com/cerana/cerana/zfs"
+)
+
+func (s *StatsPusher) TestGetDatasets() {
+	tests := []struct {
+		desc   string
+		known  []string
+		local  []string
+		result []string
+	}{
+		{"empty", []string{}, []string{}, []string{}},
+		{"known only", []string{"foo"}, []string{}, []string{}},
+		{"local only", []string{}, []string{"foo"}, []string{}},
+		{"both, single", []string{"foo"}, []string{"foo"}, []string{"foo"}},
+		{"extra local", []string{"foo"}, []string{"foo", "bar"}, []string{"foo"}},
+		{"extra known", []string{"foo", "bar"}, []string{"foo"}, []string{"foo"}},
+		{"both, multiple", []string{"foo", "bar"}, []string{"foo", "bar"}, []string{"foo", "bar"}},
+	}
+
+	for _, test := range tests {
+		fmt.Println(test.desc)
+		s.zfs.Data.Datasets = make(map[string]*zfsp.Dataset)
+		for _, name := range test.local {
+			s.zfs.Data.Datasets[name] = &zfsp.Dataset{Name: name, Properties: &zfs.DatasetProperties{Type: "volume"}}
+		}
+		fmt.Println("after local add", s.zfs.Data.Datasets)
+		s.clusterConf.Data.Datasets = make(map[string]*clusterconf.Dataset)
+		for _, id := range test.known {
+			s.clusterConf.Data.Datasets[id] = &clusterconf.Dataset{DatasetConf: &clusterconf.DatasetConf{ID: id}}
+		}
+		datasets, err := s.statsPusher.getDatasets()
+		if !s.NoError(err, test.desc) {
+			continue
+		}
+		s.Equal(test.result, datasets, test.desc)
+	}
+}
+
+func (s *StatsPusher) TestGetIP() {}
+
+func (s *StatsPusher) TestSendDatasetHeartbeats() {}

--- a/cmd/statspusher/dataset_test.go
+++ b/cmd/statspusher/dataset_test.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"fmt"
+	"net"
+	"sort"
 
 	"github.com/cerana/cerana/providers/clusterconf"
 	zfsp "github.com/cerana/cerana/providers/zfs"
@@ -25,12 +26,10 @@ func (s *StatsPusher) TestGetDatasets() {
 	}
 
 	for _, test := range tests {
-		fmt.Println(test.desc)
 		s.zfs.Data.Datasets = make(map[string]*zfsp.Dataset)
 		for _, name := range test.local {
 			s.zfs.Data.Datasets[name] = &zfsp.Dataset{Name: name, Properties: &zfs.DatasetProperties{Type: "volume"}}
 		}
-		fmt.Println("after local add", s.zfs.Data.Datasets)
 		s.clusterConf.Data.Datasets = make(map[string]*clusterconf.Dataset)
 		for _, id := range test.known {
 			s.clusterConf.Data.Datasets[id] = &clusterconf.Dataset{DatasetConf: &clusterconf.DatasetConf{ID: id}}
@@ -39,10 +38,27 @@ func (s *StatsPusher) TestGetDatasets() {
 		if !s.NoError(err, test.desc) {
 			continue
 		}
+		sort.Strings(test.result)
+		sort.Strings(datasets)
 		s.Equal(test.result, datasets, test.desc)
 	}
 }
 
-func (s *StatsPusher) TestGetIP() {}
+func (s *StatsPusher) TestGetIP() {
+	ip, err := s.statsPusher.getIP()
+	if !s.NoError(err) {
+		return
+	}
+	s.EqualValues(s.metrics.Data.Network.Interfaces[0].Addrs[0].Addr, ip.String())
+}
 
-func (s *StatsPusher) TestSendDatasetHeartbeats() {}
+func (s *StatsPusher) TestSendDatasetHeartbeats() {
+	name := "foobar"
+	s.zfs.Data.Datasets = make(map[string]*zfsp.Dataset)
+	s.zfs.Data.Datasets[name] = &zfsp.Dataset{Name: name, Properties: &zfs.DatasetProperties{Type: "volume"}}
+	s.clusterConf.Data.Datasets = make(map[string]*clusterconf.Dataset)
+	s.clusterConf.Data.Datasets[name] = &clusterconf.Dataset{DatasetConf: &clusterconf.DatasetConf{ID: name}}
+	ip := net.ParseIP(s.metrics.Data.Network.Interfaces[0].Addrs[0].Addr)
+	s.NoError(s.statsPusher.sendDatasetHeartbeats([]string{name}, ip))
+	s.True(s.clusterConf.Data.Datasets[name].Nodes[ip.String()])
+}

--- a/cmd/statspusher/doc.go
+++ b/cmd/statspusher/doc.go
@@ -1,0 +1,15 @@
+/*
+Usage:
+	$ statspusher -h
+	Usage of statspusher
+	-b, --bundleTTL uint          default timeout for requests made (seconds)
+	-c, --configFile string       path to config file
+	-u, --coordinatorURL string   url of coordinator for information retrieval
+	-d, --datasetTTL uint         default timeout for requests made (seconds)
+	-e, --heartbeatURL string     url of coordinator for the heartbeat registering
+	-l, --logLevel string         log level: debug/info/warn/error/fatal/panic (default "warning")
+	-n, --nodeTTL uint            default timeout for requests made  (seconds)
+	-r, --requestTimeout uint     default timeout for requests made (seconds)
+	Note: Flags can be used in either fooBar or foo[_-.]bar form.
+*/
+package main

--- a/cmd/statspusher/main.go
+++ b/cmd/statspusher/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/cmd/statspusher/main.go
+++ b/cmd/statspusher/main.go
@@ -1,5 +1,8 @@
 package main
 
-func main() {
+import "github.com/spf13/pflag"
 
+func main() {
+	_ = newConfig(nil, nil)
+	pflag.Parse()
 }

--- a/cmd/statspusher/main.go
+++ b/cmd/statspusher/main.go
@@ -1,8 +1,29 @@
 package main
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/cerana/cerana/pkg/logrusx"
+	"github.com/spf13/pflag"
+)
 
 func main() {
-	_ = newConfig(nil, nil)
+	logrus.SetFormatter(&logrusx.MistifyFormatter{})
+
+	config := newConfig(nil, nil)
 	pflag.Parse()
+
+	dieOnError(config.loadConfig())
+	dieOnError(config.setupLogging())
+
+	sp, err := newStatsPusher(config)
+	dieOnError(err)
+
+	dieOnError(sp.run())
+	sp.stopOnSignal()
+}
+
+func dieOnError(err error) {
+	if err != nil {
+		logrus.Fatal("encountered an error during startup")
+	}
 }

--- a/cmd/statspusher/main.go
+++ b/cmd/statspusher/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	logrus.SetFormatter(&logrusx.MistifyFormatter{})
+	logrus.SetFormatter(&logrusx.JSONFormatter{})
 
 	config := newConfig(nil, nil)
 	pflag.Parse()

--- a/cmd/statspusher/node.go
+++ b/cmd/statspusher/node.go
@@ -31,7 +31,7 @@ func (s *statsPusher) getNodeInfo() (*clusterconf.Node, error) {
 	}
 	requests := make(map[string]*acomm.Request)
 	for task := range tasks {
-		requests[task], err = acomm.NewRequest(acomm.RequestOptions{Task: "task"})
+		requests[task], err = acomm.NewRequest(acomm.RequestOptions{Task: task})
 		if err != nil {
 			return nil, err
 		}
@@ -40,9 +40,11 @@ func (s *statsPusher) getNodeInfo() (*clusterconf.Node, error) {
 	multiRequest := acomm.NewMultiRequest(s.tracker, s.config.requestTimeout())
 	for name, req := range requests {
 		if err := multiRequest.AddRequest(name, req); err != nil {
+			fmt.Println("failed to add")
 			break
 		}
 		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+			fmt.Println(name, err)
 			multiRequest.RemoveRequest(req)
 			break
 		}
@@ -95,7 +97,7 @@ func (s *statsPusher) sendNodeHeartbeat(data *clusterconf.Node) error {
 		Task:           "node-heartbeat",
 		TaskURL:        s.config.heartbeatURL(),
 		ResponseHook:   s.tracker.URL(),
-		Args:           data,
+		Args:           &clusterconf.NodePayload{data},
 		SuccessHandler: rh,
 		ErrorHandler:   rh,
 	})

--- a/cmd/statspusher/node.go
+++ b/cmd/statspusher/node.go
@@ -97,7 +97,7 @@ func (s *statsPusher) sendNodeHeartbeat(data *clusterconf.Node) error {
 		Task:           "node-heartbeat",
 		TaskURL:        s.config.heartbeatURL(),
 		ResponseHook:   s.tracker.URL(),
-		Args:           &clusterconf.NodePayload{data},
+		Args:           &clusterconf.NodePayload{Node: data},
 		SuccessHandler: rh,
 		ErrorHandler:   rh,
 	})

--- a/cmd/statspusher/node.go
+++ b/cmd/statspusher/node.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/providers/clusterconf"
+	"github.com/cerana/cerana/providers/metrics"
+	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/host"
+)
+
+func (s *statsPusher) nodeHeartbeat() error {
+	node, err := s.getNodeInfo()
+	if err != nil {
+		return err
+	}
+	return s.sendNodeHeartbeat(node)
+}
+
+func (s *statsPusher) getNodeInfo() (*clusterconf.Node, error) {
+	var err error
+
+	tasks := map[string]interface{}{
+		"metrics-cpu":    &metrics.CPUResult{},
+		"metrics-disk":   &metrics.DiskResult{},
+		"metrics-host":   &host.InfoStat{},
+		"metrics-memory": &metrics.MemoryResult{},
+	}
+	requests := make(map[string]*acomm.Request)
+	for task := range tasks {
+		requests[task], err = acomm.NewRequest(acomm.RequestOptions{Task: "task"})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	multiRequest := acomm.NewMultiRequest(s.tracker, s.config.requestTimeout())
+	for name, req := range requests {
+		if err := multiRequest.AddRequest(name, req); err != nil {
+			break
+		}
+		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+			multiRequest.RemoveRequest(req)
+			break
+		}
+	}
+
+	responses := multiRequest.Responses()
+	for name := range requests {
+		resp, ok := responses[name]
+		if !ok {
+			return nil, fmt.Errorf("failed to send request: %s", name)
+		}
+		if resp.Error != nil {
+			return nil, fmt.Errorf("request failed: %s: %s", name, resp.Error)
+		}
+		if err := resp.UnmarshalResult(tasks[name]); err != nil {
+			return nil, err
+		}
+	}
+
+	usages := tasks["metrics-disk"].(*metrics.DiskResult).Usage
+	var usage *disk.UsageStat
+	for _, u := range usages {
+		if u.Path == "/" {
+			usage = u
+			break
+		}
+	}
+	if usage == nil {
+		return nil, errors.New("failed to determine disk usage")
+	}
+
+	return &clusterconf.Node{
+		ID:          tasks["metrics-host"].(*host.InfoStat).Hostname,
+		Heartbeat:   time.Now(),
+		MemoryTotal: tasks["metrics-memory"].(*metrics.MemoryResult).Virtual.Total,
+		MemoryFree:  tasks["metrics-memory"].(*metrics.MemoryResult).Virtual.Available,
+		CPUCores:    len(tasks["metrics-cpu"].(*metrics.CPUResult).Info),
+		CPULoad:     tasks["metrics-cpu"].(*metrics.CPUResult).Load,
+		DiskTotal:   usage.Total,
+		DiskFree:    usage.Free,
+	}, nil
+}
+
+func (s *statsPusher) sendNodeHeartbeat(data *clusterconf.Node) error {
+	doneChan := make(chan error, 1)
+	rh := func(_ *acomm.Request, resp *acomm.Response) {
+		doneChan <- resp.Error
+	}
+	req, err := acomm.NewRequest(acomm.RequestOptions{
+		Task:           "node-heartbeat",
+		TaskURL:        s.config.heartbeatURL(),
+		ResponseHook:   s.tracker.URL(),
+		Args:           data,
+		SuccessHandler: rh,
+		ErrorHandler:   rh,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := s.tracker.TrackRequest(req, s.config.requestTimeout()); err != nil {
+		return err
+	}
+	if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		_ = s.tracker.RemoveRequest(req)
+		return err
+	}
+
+	return <-doneChan
+}

--- a/cmd/statspusher/node_test.go
+++ b/cmd/statspusher/node_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"time"
+
+	"github.com/cerana/cerana/providers/clusterconf"
+	"github.com/pborman/uuid"
+)
+
+func (s *StatsPusher) TestGetNodeInfo() {
+	data, err := s.statsPusher.getNodeInfo()
+	if !s.NoError(err) {
+		return
+	}
+	s.Equal(s.metrics.Data.Host.Hostname, data.ID)
+	s.Equal(s.metrics.Data.Memory.Virtual.Total, data.MemoryTotal)
+	s.Equal(s.metrics.Data.Memory.Virtual.Available, data.MemoryFree)
+	s.Equal(len(s.metrics.Data.CPU.Info), data.CPUCores)
+	s.Equal(s.metrics.Data.CPU.Load, data.CPULoad)
+	s.Equal(s.metrics.Data.Disk.Usage[0].Total, data.DiskTotal)
+	s.Equal(s.metrics.Data.Disk.Usage[0].Free, data.DiskFree)
+	s.WithinDuration(time.Now(), data.Heartbeat, time.Millisecond)
+}
+
+func (s *StatsPusher) TestSendNodeHeartbeat() {
+	data := &clusterconf.Node{
+		ID:        uuid.New(),
+		Heartbeat: time.Now(),
+	}
+
+	if !s.NoError(s.statsPusher.sendNodeHeartbeat(data)) {
+		return
+	}
+
+	_, ok := s.clusterConf.Data.Nodes[data.ID]
+	s.True(ok)
+}

--- a/cmd/statspusher/statspusher.go
+++ b/cmd/statspusher/statspusher.go
@@ -1,8 +1,95 @@
 package main
 
-import "github.com/cerana/cerana/acomm"
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/cerana/cerana/acomm"
+)
 
 type statsPusher struct {
-	config  *config
-	tracker *acomm.Tracker
+	config   *config
+	tracker  *acomm.Tracker
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+}
+
+func newStatsPusher(c *config) (*statsPusher, error) {
+	tracker, err := acomm.NewTracker("", nil, nil, c.requestTimeout())
+	if err != nil {
+		return nil, err
+	}
+
+	return &statsPusher{
+		config:   c,
+		tracker:  tracker,
+		stopChan: make(chan struct{}),
+	}, nil
+}
+
+func (s *statsPusher) run() error {
+	if err := s.tracker.Start(); err != nil {
+		return err
+	}
+	s.startHeartbeat("node", s.nodeHeartbeat, s.config.nodeTTL())
+	s.startHeartbeat("dataset", s.datasetHeartbeats, s.config.datasetTTL())
+	s.startHeartbeat("bundle", s.bundleHeartbeats, s.config.bundleTTL())
+	return nil
+}
+
+func (s *statsPusher) startHeartbeat(name string, fn func() error, desiredInterval time.Duration) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		lastStart := time.Time{}
+		for {
+			// Try to start fn at the desired time interval, accounting for
+			// time time it takes for fn to complete while also preventing fn
+			// from running more than once at a time.
+			interval := desiredInterval
+			since := time.Since(lastStart)
+			if since < interval {
+				interval = since
+			}
+			timeChan := time.After(interval)
+
+			select {
+			case <-s.stopChan:
+				break
+			case lastStart = <-timeChan:
+				if err := fn(); err != nil {
+					logrus.WithFields(logrus.Fields{
+						"name":  name,
+						"error": err,
+					}).Error("error while running heartbeat")
+				}
+			}
+		}
+	}()
+}
+
+func (s *statsPusher) stop() {
+	close(s.stopChan)
+	s.wg.Wait()
+
+	s.tracker.Stop()
+}
+
+func (s *statsPusher) stopOnSignal(signals ...os.Signal) {
+	if len(signals) == 0 {
+		signals = []os.Signal{os.Interrupt, os.Kill, syscall.SIGTERM}
+	}
+
+	sigChan := make(chan os.Signal)
+	signal.Notify(sigChan, signals...)
+	sig := <-sigChan
+	logrus.WithFields(logrus.Fields{
+		"signal": sig,
+	}).Info("signal received, stopping")
+
+	s.stop()
 }

--- a/cmd/statspusher/statspusher.go
+++ b/cmd/statspusher/statspusher.go
@@ -48,19 +48,18 @@ func (s *statsPusher) startHeartbeat(name string, fn func() error, desiredInterv
 		lastStart := time.Time{}
 		for {
 			// Try to start fn at the desired time interval, accounting for
-			// time time it takes for fn to complete while also preventing fn
+			// the time it takes for fn to complete while also preventing fn
 			// from running more than once at a time.
 			interval := desiredInterval
 			since := time.Since(lastStart)
 			if since < interval {
 				interval = since
 			}
-			timeChan := time.After(interval)
 
 			select {
 			case <-s.stopChan:
 				break
-			case lastStart = <-timeChan:
+			case lastStart = <-time.After(interval):
 				if err := fn(); err != nil {
 					logrus.WithFields(logrus.Fields{
 						"name":  name,

--- a/cmd/statspusher/statspusher.go
+++ b/cmd/statspusher/statspusher.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/cerana/cerana/acomm"
+
+type statsPusher struct {
+	config  *config
+	tracker *acomm.Tracker
+}

--- a/cmd/statspusher/statspusher_test.go
+++ b/cmd/statspusher/statspusher_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/test"
+	"github.com/cerana/cerana/provider"
+	"github.com/cerana/cerana/providers/clusterconf"
+	"github.com/cerana/cerana/providers/systemd"
+	"github.com/cerana/cerana/providers/zfs"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/suite"
+)
+
+type StatsPusher struct {
+	suite.Suite
+	config      *config
+	configData  *ConfigData
+	configFile  *os.File
+	coordinator *test.Coordinator
+	tracker     *acomm.Tracker
+	systemd     *systemd.MockSystemd
+	zfs         *zfs.MockZFS
+	clusterConf *clusterconf.MockClusterConf
+}
+
+func TestStatsPusher(t *testing.T) {
+	suite.Run(t, new(StatsPusher))
+}
+
+func (s *StatsPusher) SetupSuite() {
+	noError := s.Require().NoError
+
+	logrus.SetLevel(logrus.FatalLevel)
+
+	// Setup mock coordinator
+	var err error
+	s.coordinator, err = test.NewCoordinator("")
+	noError(err)
+
+	coordinatorURL := s.coordinator.NewProviderViper().GetString("coordinator_url")
+	s.configData = &ConfigData{
+		CoordinatorURL: coordinatorURL,
+		HeartbeatURL:   coordinatorURL,
+		LogLevel:       "fatal",
+		RequestTimeout: 5,
+		DatasetTTL:     4,
+		BundleTTL:      3,
+		NodeTTL:        2,
+	}
+
+	s.config, _, _, s.configFile, err = newTestConfig(false, true, s.configData)
+	noError(err, "failed to create config")
+	noError(s.config.loadConfig(), "failed to load config")
+
+	// Setup mock coordinator and providers
+	s.coordinator, err = test.NewCoordinator("")
+	noError(err)
+
+	s.tracker, err = acomm.NewTracker(filepath.Join(s.coordinator.SocketDir, "tracker.sock"), nil, nil, 5*time.Second)
+	noError(err)
+
+	s.setupSystemd()
+	s.setupZFS()
+	s.setupClusterConf()
+
+	noError(s.coordinator.Start())
+}
+
+func (s *StatsPusher) setupClusterConf() {
+	s.clusterConf = clusterconf.NewMockClusterConf()
+	s.coordinator.RegisterProvider(s.clusterConf)
+}
+
+func (s *StatsPusher) setupZFS() {
+	v := s.coordinator.NewProviderViper()
+	flagset := pflag.NewFlagSet("zfs", pflag.PanicOnError)
+	config := provider.NewConfig(flagset, v)
+	s.Require().NoError(flagset.Parse([]string{}))
+	s.Require().NoError(config.LoadConfig())
+	s.zfs = zfs.NewMockZFS(config, s.tracker)
+	s.coordinator.RegisterProvider(s.zfs)
+}
+
+func (s *StatsPusher) setupSystemd() {
+	s.systemd = systemd.NewMockSystemd()
+	s.coordinator.RegisterProvider(s.systemd)
+}
+
+func (s *StatsPusher) TearDownSuite() {
+	s.coordinator.Stop()
+	s.Require().NoError(s.coordinator.Cleanup())
+	_ = os.Remove(s.configFile.Name())
+}

--- a/cmd/statspusher/statspusher_test.go
+++ b/cmd/statspusher/statspusher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cerana/cerana/pkg/test"
 	"github.com/cerana/cerana/provider"
 	"github.com/cerana/cerana/providers/clusterconf"
+	"github.com/cerana/cerana/providers/metrics"
 	"github.com/cerana/cerana/providers/systemd"
 	"github.com/cerana/cerana/providers/zfs"
 	"github.com/spf13/pflag"
@@ -26,6 +27,7 @@ type StatsPusher struct {
 	systemd     *systemd.MockSystemd
 	zfs         *zfs.MockZFS
 	clusterConf *clusterconf.MockClusterConf
+	metrics     *metrics.MockMetrics
 }
 
 func TestStatsPusher(t *testing.T) {
@@ -67,6 +69,7 @@ func (s *StatsPusher) SetupSuite() {
 	s.setupSystemd()
 	s.setupZFS()
 	s.setupClusterConf()
+	s.setupMetrics()
 
 	noError(s.coordinator.Start())
 }
@@ -89,6 +92,11 @@ func (s *StatsPusher) setupZFS() {
 func (s *StatsPusher) setupSystemd() {
 	s.systemd = systemd.NewMockSystemd()
 	s.coordinator.RegisterProvider(s.systemd)
+}
+
+func (s *StatsPusher) setupMetrics() {
+	s.metrics = metrics.NewMockMetrics()
+	s.coordinator.RegisterProvider(s.metrics)
 }
 
 func (s *StatsPusher) TearDownSuite() {

--- a/coordinator/server.go
+++ b/coordinator/server.go
@@ -235,9 +235,16 @@ func (s *Server) localTask(req *acomm.Request) error {
 // service (e.g. another coordinator)
 func (s *Server) externalTask(req *acomm.Request) error {
 	taskURL := req.TaskURL
-	proxyReq, err := s.proxy.ProxyExternal(req, 0)
-	if err != nil {
-		return err
+	proxyReq := req
+	if taskURL.Scheme != "unix" {
+		var err error
+		proxyReq, err = s.proxy.ProxyExternal(req, 0)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Don't proxy local requests
+		proxyReq.TaskURL = nil
 	}
 	return acomm.Send(taskURL, proxyReq)
 }

--- a/pkg/test/README.md
+++ b/pkg/test/README.md
@@ -45,7 +45,7 @@ appropriate values corresponding to the coordinator and provider server.
 ```go
 func (c *Coordinator) ProviderTracker() *acomm.Tracker
 ```
-ProviderTracker exposes the provider server tracker.
+ProviderTracker returns the tracker of the provider server.
 
 #### func (*Coordinator) RegisterProvider
 

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -102,11 +102,6 @@ func (c *Coordinator) RegisterProvider(p provider.Provider) {
 	p.RegisterTasks(c.providerServer)
 }
 
-// ProviderTracker exposes the provider server tracker.
-func (c *Coordinator) ProviderTracker() *acomm.Tracker {
-	return c.providerServer.Tracker()
-}
-
 // Start starts the Coordinator and Provider servers.
 func (c *Coordinator) Start() error {
 	if err := c.coordinator.Start(); err != nil {

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -91,6 +91,7 @@ func (c *Coordinator) NewProviderViper() *viper.Viper {
 	return v
 }
 
+// ProviderTracker returns the tracker of the provider server.
 func (c *Coordinator) ProviderTracker() *acomm.Tracker {
 	return c.providerServer.Tracker()
 }

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -91,6 +91,10 @@ func (c *Coordinator) NewProviderViper() *viper.Viper {
 	return v
 }
 
+func (c *Coordinator) ProviderTracker() *acomm.Tracker {
+	return c.providerServer.Tracker()
+}
+
 // RegisterProvider registers a Provider's tasks with the internal Provider
 // server.
 func (c *Coordinator) RegisterProvider(p provider.Provider) {

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -234,12 +234,12 @@ func (c *ClusterConf) GetService(req *acomm.Request) (interface{}, *url.URL, err
 ```
 GetService retrieves a service.
 
-#### func (*ClusterConf) ListBundle
+#### func (*ClusterConf) ListBundles
 
 ```go
-func (c *ClusterConf) ListBundle(req *acomm.Request) (interface{}, *url.URL, error)
+func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error)
 ```
-ListBundle retrieves a bundle.
+ListBundles retrieves a bundle.
 
 #### func (*ClusterConf) ListDatasets
 
@@ -470,6 +470,171 @@ type IDArgs struct {
 
 IDArgs are arguments for operations requiring only an ID.
 
+#### type MockClusterConf
+
+```go
+type MockClusterConf struct {
+	Data *MockClusterData
+}
+```
+
+MockClusterConf is a mock ClusterConf provider.
+
+#### func  NewMockClusterConf
+
+```go
+func NewMockClusterConf() *MockClusterConf
+```
+NewMockClusterConf creates a new MockClusterConf.
+
+#### func (*MockClusterConf) BundleHeartbeat
+
+```go
+func (c *MockClusterConf) BundleHeartbeat(req *acomm.Request) (interface{}, *url.URL, error)
+```
+BundleHeartbeat adds a mock bundle heartbeat.
+
+#### func (*MockClusterConf) DatasetHeartbeat
+
+```go
+func (c *MockClusterConf) DatasetHeartbeat(req *acomm.Request) (interface{}, *url.URL, error)
+```
+DatasetHeartbeat adds a mock dataset heartbeat.
+
+#### func (*MockClusterConf) DeleteBundle
+
+```go
+func (c *MockClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.URL, error)
+```
+DeleteBundle removes a mock bundle.
+
+#### func (*MockClusterConf) DeleteDataset
+
+```go
+func (c *MockClusterConf) DeleteDataset(req *acomm.Request) (interface{}, *url.URL, error)
+```
+DeleteDataset removes a mock dataset.
+
+#### func (*MockClusterConf) DeleteService
+
+```go
+func (c *MockClusterConf) DeleteService(req *acomm.Request) (interface{}, *url.URL, error)
+```
+DeleteService removes a mock service.
+
+#### func (*MockClusterConf) GetBundle
+
+```go
+func (c *MockClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, error)
+```
+GetBundle retrieves a mock bundle.
+
+#### func (*MockClusterConf) GetDataset
+
+```go
+func (c *MockClusterConf) GetDataset(req *acomm.Request) (interface{}, *url.URL, error)
+```
+GetDataset retrieves a mock dataset.
+
+#### func (*MockClusterConf) GetDefaults
+
+```go
+func (c *MockClusterConf) GetDefaults(req *acomm.Request) (interface{}, *url.URL, error)
+```
+GetDefaults retrieves the mock default values.
+
+#### func (*MockClusterConf) GetNode
+
+```go
+func (c *MockClusterConf) GetNode(req *acomm.Request) (interface{}, *url.URL, error)
+```
+GetNode retrieves a mock node.
+
+#### func (*MockClusterConf) GetNodesHistory
+
+```go
+func (c *MockClusterConf) GetNodesHistory(req *acomm.Request) (interface{}, *url.URL, error)
+```
+GetNodesHistory retrieves mock nodes history.
+
+#### func (*MockClusterConf) GetService
+
+```go
+func (c *MockClusterConf) GetService(req *acomm.Request) (interface{}, *url.URL, error)
+```
+GetService retrieves a mock service.
+
+#### func (*MockClusterConf) ListBundles
+
+```go
+func (c *MockClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error)
+```
+ListBundles retrieves all mock bundles.
+
+#### func (*MockClusterConf) ListDatasets
+
+```go
+func (c *MockClusterConf) ListDatasets(req *acomm.Request) (interface{}, *url.URL, error)
+```
+ListDatasets lists all mock datasets.
+
+#### func (*MockClusterConf) NodeHeartbeat
+
+```go
+func (c *MockClusterConf) NodeHeartbeat(req *acomm.Request) (interface{}, *url.URL, error)
+```
+NodeHeartbeat adds a mock node heartbeat.
+
+#### func (*MockClusterConf) RegisterTasks
+
+```go
+func (c *MockClusterConf) RegisterTasks(server *provider.Server)
+```
+RegisterTasks registers all of MockClusterConf's tasks.
+
+#### func (*MockClusterConf) UpdateBundle
+
+```go
+func (c *MockClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.URL, error)
+```
+UpdateBundle updates a mock bundle.
+
+#### func (*MockClusterConf) UpdateDataset
+
+```go
+func (c *MockClusterConf) UpdateDataset(req *acomm.Request) (interface{}, *url.URL, error)
+```
+UpdateDataset updates a mock dataset.
+
+#### func (*MockClusterConf) UpdateDefaults
+
+```go
+func (c *MockClusterConf) UpdateDefaults(req *acomm.Request) (interface{}, *url.URL, error)
+```
+UpdateDefaults updates the mock default values.
+
+#### func (*MockClusterConf) UpdateService
+
+```go
+func (c *MockClusterConf) UpdateService(req *acomm.Request) (interface{}, *url.URL, error)
+```
+UpdateService updates a mock service.
+
+#### type MockClusterData
+
+```go
+type MockClusterData struct {
+	Services map[string]*Service
+	Bundles  map[int]*Bundle
+	Datasets map[string]*Dataset
+	Nodes    map[string]*Node
+	History  NodesHistory
+	Defaults *Defaults
+}
+```
+
+MockClusterData is the in-memory data structure for a MockClusterConf.
+
 #### type Node
 
 ```go
@@ -490,7 +655,7 @@ Node is current information about a hardware node.
 #### type NodeHistory
 
 ```go
-type NodeHistory map[time.Time]Node
+type NodeHistory map[time.Time]*Node
 ```
 
 NodeHistory is a set of historical information for a node.
@@ -530,7 +695,7 @@ NodesHistory is the historical information for multiple nodes.
 
 ```go
 type NodesHistoryResult struct {
-	History *NodesHistory `json:"history"`
+	History NodesHistory `json:"history"`
 }
 ```
 

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -625,7 +625,7 @@ UpdateService updates a mock service.
 ```go
 type MockClusterData struct {
 	Services map[string]*Service
-	Bundles  map[int]*Bundle
+	Bundles  map[uint64]*Bundle
 	Datasets map[string]*Dataset
 	Nodes    map[string]*Node
 	History  NodesHistory

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -239,7 +239,7 @@ GetService retrieves a service.
 ```go
 func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error)
 ```
-ListBundles retrieves a bundle.
+ListBundles retrieves a list of all bundles.
 
 #### func (*ClusterConf) ListDatasets
 

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -71,6 +71,16 @@ type BundleIDArgs struct {
 
 BundleIDArgs are args for bundle tasks that only require bundle id.
 
+#### type BundleListResult
+
+```go
+type BundleListResult struct {
+	Bundles []*Bundle `json:"bundles"`
+}
+```
+
+BundleListResult is the result from listing bundles.
+
 #### type BundlePayload
 
 ```go
@@ -224,6 +234,20 @@ func (c *ClusterConf) GetService(req *acomm.Request) (interface{}, *url.URL, err
 ```
 GetService retrieves a service.
 
+#### func (*ClusterConf) ListBundle
+
+```go
+func (c *ClusterConf) ListBundle(req *acomm.Request) (interface{}, *url.URL, error)
+```
+ListBundle retrieves a bundle.
+
+#### func (*ClusterConf) ListDatasets
+
+```go
+func (c *ClusterConf) ListDatasets(req *acomm.Request) (interface{}, *url.URL, error)
+```
+ListDatasets returns a list of all Datasets.
+
 #### func (*ClusterConf) NodeHeartbeat
 
 ```go
@@ -370,6 +394,16 @@ type DatasetHeartbeatArgs struct {
 
 DatasetHeartbeatArgs are arguments for updating a dataset node heartbeat.
 
+#### type DatasetListResult
+
+```go
+type DatasetListResult struct {
+	Datasets []*Dataset `json:"datasets"`
+}
+```
+
+DatasetListResult is the result for listing datasets.
+
 #### type DatasetPayload
 
 ```go
@@ -440,14 +474,14 @@ IDArgs are arguments for operations requiring only an ID.
 
 ```go
 type Node struct {
-	ID          string    `json:"id"`
-	Heartbeat   time.Time `json:"heartbeat"`
-	MemoryTotal int64     `json:"memoryTotal"`
-	MemoryFree  int64     `json:"memoryFree"`
-	CPUTotal    int       `json:"cpuTotal"`
-	CPUFree     int       `json:"cpuFree"`
-	DiskTotal   int       `json:"diskTotal"`
-	DiskFree    int       `json:"diskFree"`
+	ID          string       `json:"id"`
+	Heartbeat   time.Time    `json:"heartbeat"`
+	MemoryTotal uint64       `json:"memoryTotal"`
+	MemoryFree  uint64       `json:"memoryFree"`
+	CPUCores    int          `json:"cpuCores"`
+	CPULoad     load.AvgStat `json:"cpuLoad"`
+	DiskTotal   uint64       `json:"diskTotal"`
+	DiskFree    uint64       `json:"diskFree"`
 }
 ```
 

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -226,6 +226,9 @@ func (c *ClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.URL, e
 
 	bundle, err := c.getBundle(args.ID)
 	if err != nil {
+		if err.Error() == "bundle config not found" {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -140,7 +140,7 @@ func (c *ClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, erro
 	return &BundlePayload{bundle}, nil, nil
 }
 
-// ListBundles retrieves a bundle.
+// ListBundles retrieves a list of all bundles.
 func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error) {
 	keys, err := c.kvKeys(bundlesPrefix)
 	if err != nil {

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -147,12 +147,12 @@ func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, er
 		return nil, nil, err
 	}
 	// extract and deduplicate the bundle ids
-	ids := make(map[int]bool)
+	ids := make(map[uint64]bool)
 	for _, key := range keys {
 		// keys are full paths and include all child keys.
 		// e.g. {prefix}/{id}/{rest/of/path}
 		idS := strings.Split(strings.TrimPrefix(key, bundlesPrefix), "/")[0]
-		id, err := strconv.Atoi(idS)
+		id, err := strconv.ParseUint(idS, 10, 64)
 		if err != nil {
 			return nil, nil, errors.New("invalid bundle id")
 		}
@@ -166,7 +166,7 @@ func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, er
 	defer close(errChan)
 	for id := range ids {
 		wg.Add(1)
-		go func(id int) {
+		go func(id uint64) {
 			defer wg.Done()
 			ds, err := c.getBundle(id)
 			if err != nil {

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/cerana/cerana/acomm"
@@ -109,6 +111,11 @@ type BundlePayload struct {
 	Bundle *Bundle `json:"bundle"`
 }
 
+// BundleListResult is the result from listing bundles.
+type BundleListResult struct {
+	Bundles []*Bundle `json:"bundles"`
+}
+
 // BundleHeartbeatArgs are arguments for updating a dataset node heartbeat.
 type BundleHeartbeatArgs struct {
 	ID     uint64 `json:"id"`
@@ -133,8 +140,59 @@ func (c *ClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, erro
 	return &BundlePayload{bundle}, nil, nil
 }
 
-// UpdateBundle creates or updates a bundle config.
-// When updating, a Get should first be performed and the modified Bundle passed back.
+// ListBundle retrieves a bundle.
+func (c *ClusterConf) ListBundle(req *acomm.Request) (interface{}, *url.URL, error) {
+	keys, err := c.kvKeys(bundlesPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	// extract and deduplicate the bundle ids
+	ids := make(map[int]bool)
+	for _, key := range keys {
+		// keys are full paths and include all child keys.
+		// e.g. {prefix}/{id}/{rest/of/path}
+		idS := strings.Split(strings.TrimPrefix(key, bundlesPrefix), "/")[0]
+		id, err := strconv.Atoi(idS)
+		if err != nil {
+			return nil, nil, errors.New("invalid bundle id")
+		}
+		ids[id] = true
+	}
+
+	var wg sync.WaitGroup
+	dsChan := make(chan *Bundle, len(ids))
+	defer close(dsChan)
+	errChan := make(chan error, len(ids))
+	defer close(errChan)
+	for id := range ids {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			ds, err := c.getBundle(id)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			dsChan <- ds
+		}(id)
+	}
+	wg.Wait()
+
+	if len(errChan) > 0 {
+		err := <-errChan
+		return nil, nil, err
+	}
+	bundles := make([]*Bundle, 0, len(dsChan))
+	for ds := range dsChan {
+		bundles = append(bundles, ds)
+	}
+
+	return &BundleListResult{
+		Bundles: bundles,
+	}, nil, nil
+}
+
+// UpdateBundle creates or updates a bundle config. When updating, a Get should first be performed and the modified Bundle passed back.
 func (c *ClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args BundlePayload
 	if err := req.UnmarshalArgs(&args); err != nil {

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -140,8 +140,8 @@ func (c *ClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, erro
 	return &BundlePayload{bundle}, nil, nil
 }
 
-// ListBundle retrieves a bundle.
-func (c *ClusterConf) ListBundle(req *acomm.Request) (interface{}, *url.URL, error) {
+// ListBundles retrieves a bundle.
+func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error) {
 	keys, err := c.kvKeys(bundlesPrefix)
 	if err != nil {
 		return nil, nil, err

--- a/providers/clusterconf/bundle_test.go
+++ b/providers/clusterconf/bundle_test.go
@@ -110,7 +110,7 @@ func (s *clusterConf) TestDeleteBundle() {
 		err string
 	}{
 		{0, "missing arg: id"},
-		{uint64(rand.Int63()), "bundle config not found"},
+		{uint64(rand.Int63()), ""},
 		{bundle.ID, ""},
 	}
 

--- a/providers/clusterconf/clusterconf.go
+++ b/providers/clusterconf/clusterconf.go
@@ -31,6 +31,7 @@ func New(config *Config, tracker *acomm.Tracker) *ClusterConf {
 // RegisterTasks registers all of Systemd's task handlers with the server.
 func (c *ClusterConf) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("get-bundle", c.GetBundle)
+	server.RegisterTask("list-bundles", c.ListBundles)
 	server.RegisterTask("update-bundle", c.UpdateBundle)
 	server.RegisterTask("delete-bundle", c.DeleteBundle)
 	server.RegisterTask("bundle-heartbeat", c.BundleHeartbeat)

--- a/providers/clusterconf/clusterconf.go
+++ b/providers/clusterconf/clusterconf.go
@@ -35,6 +35,7 @@ func (c *ClusterConf) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("delete-bundle", c.DeleteBundle)
 	server.RegisterTask("bundle-heartbeat", c.BundleHeartbeat)
 	server.RegisterTask("get-dataset", c.GetDataset)
+	server.RegisterTask("list-datasets", c.ListDatasets)
 	server.RegisterTask("update-dataset", c.UpdateDataset)
 	server.RegisterTask("delete-dataset", c.DeleteDataset)
 	server.RegisterTask("dataset-heartbeat", c.DeleteDataset)

--- a/providers/clusterconf/clusterconf.go
+++ b/providers/clusterconf/clusterconf.go
@@ -85,6 +85,22 @@ func (c *ClusterConf) kvReq(task string, args map[string]interface{}) (*acomm.Re
 	return resp, resp.Error
 }
 
+func (c *ClusterConf) kvKeys(prefix string) ([]string, error) {
+	args := map[string]interface{}{
+		"key": prefix,
+	}
+
+	resp, err := c.kvReq("kv-keys", args)
+	if err != nil {
+		return nil, err
+	}
+	var values []string
+	if err := resp.UnmarshalResult(&values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
 func (c *ClusterConf) kvGetAll(key string) (map[string]kv.Value, error) {
 	args := map[string]interface{}{
 		"key": key,

--- a/providers/clusterconf/dataset.go
+++ b/providers/clusterconf/dataset.go
@@ -72,6 +72,7 @@ func (c *ClusterConf) GetDataset(req *acomm.Request) (interface{}, *url.URL, err
 	return &DatasetPayload{dataset}, nil, nil
 }
 
+// ListDatasets returns a list of all Datasets.
 func (c *ClusterConf) ListDatasets(req *acomm.Request) (interface{}, *url.URL, error) {
 	keys, err := c.kvKeys(datasetsPrefix)
 	if err != nil {

--- a/providers/clusterconf/dataset.go
+++ b/providers/clusterconf/dataset.go
@@ -153,6 +153,9 @@ func (c *ClusterConf) DeleteDataset(req *acomm.Request) (interface{}, *url.URL, 
 
 	dataset, err := c.getDataset(args.ID)
 	if err != nil {
+		if err.Error() == "dataset config not found" {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 

--- a/providers/clusterconf/dataset.go
+++ b/providers/clusterconf/dataset.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/cerana/cerana/acomm"
 	"github.com/pborman/uuid"
@@ -42,6 +44,11 @@ type DatasetPayload struct {
 	Dataset *Dataset `json:"dataset"`
 }
 
+// DatasetListResult is the result for listing datasets.
+type DatasetListResult struct {
+	Datasets []*Dataset `json:"datasets"`
+}
+
 // DatasetHeartbeatArgs are arguments for updating a dataset node heartbeat.
 type DatasetHeartbeatArgs struct {
 	ID string `json:"id"`
@@ -63,6 +70,53 @@ func (c *ClusterConf) GetDataset(req *acomm.Request) (interface{}, *url.URL, err
 		return nil, nil, err
 	}
 	return &DatasetPayload{dataset}, nil, nil
+}
+
+func (c *ClusterConf) ListDatasets(req *acomm.Request) (interface{}, *url.URL, error) {
+	keys, err := c.kvKeys(datasetsPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	// extract and deduplicate the dataset ids
+	ids := make(map[string]bool)
+	for _, key := range keys {
+		// keys are full paths and include all child keys.
+		// e.g. {prefix}/{id}/{rest/of/path}
+		id := strings.Split(strings.TrimPrefix(key, datasetsPrefix), "/")[0]
+		ids[id] = true
+	}
+
+	var wg sync.WaitGroup
+	dsChan := make(chan *Dataset, len(ids))
+	defer close(dsChan)
+	errChan := make(chan error, len(ids))
+	defer close(errChan)
+	for id := range ids {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			ds, err := c.getDataset(id)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			dsChan <- ds
+		}(id)
+	}
+	wg.Wait()
+
+	if len(errChan) > 0 {
+		err := <-errChan
+		return nil, nil, err
+	}
+	datasets := make([]*Dataset, 0, len(dsChan))
+	for ds := range dsChan {
+		datasets = append(datasets, ds)
+	}
+
+	return &DatasetListResult{
+		Datasets: datasets,
+	}, nil, nil
 }
 
 // UpdateDataset creates or updates a dataset config. When updating, a Get should first be performed and the modified Dataset passed back.

--- a/providers/clusterconf/dataset_test.go
+++ b/providers/clusterconf/dataset_test.go
@@ -107,7 +107,7 @@ func (s *clusterConf) TestDeleteDataset() {
 		err string
 	}{
 		{"", "missing arg: id"},
-		{"does-not-exist", "dataset config not found"},
+		{"does-not-exist", ""},
 		{dataset.ID, ""},
 	}
 

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -20,7 +20,7 @@ type MockClusterConf struct {
 // MockClusterData is the in-memory data structure for a MockClusterConf.
 type MockClusterData struct {
 	Services map[string]*Service
-	Bundles  map[int]*Bundle
+	Bundles  map[uint64]*Bundle
 	Datasets map[string]*Dataset
 	Nodes    map[string]*Node
 	History  NodesHistory
@@ -32,7 +32,7 @@ func NewMockClusterConf() *MockClusterConf {
 	return &MockClusterConf{
 		Data: &MockClusterData{
 			Services: make(map[string]*Service),
-			Bundles:  make(map[int]*Bundle),
+			Bundles:  make(map[uint64]*Bundle),
 			Datasets: make(map[string]*Dataset),
 			Nodes:    make(map[string]*Node),
 			History:  make(NodesHistory),
@@ -99,7 +99,7 @@ func (c *MockClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.UR
 
 	if args.Bundle.ID == 0 {
 		rand.Seed(time.Now().UnixNano())
-		args.Bundle.ID = rand.Int()
+		args.Bundle.ID = uint64(rand.Int63())
 	}
 
 	args.Bundle.ModIndex++

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -117,11 +117,6 @@ func (c *MockClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.UR
 		return nil, nil, errors.New("missing arg: id")
 	}
 
-	_, ok := c.Data.Bundles[args.ID]
-	if !ok {
-		return nil, nil, errors.New("bundle config not found")
-	}
-
 	delete(c.Data.Bundles, args.ID)
 	return nil, nil, nil
 }
@@ -206,11 +201,6 @@ func (c *MockClusterConf) DeleteDataset(req *acomm.Request) (interface{}, *url.U
 	}
 	if args.ID == "" {
 		return nil, nil, errors.New("missing arg: id")
-	}
-
-	_, ok := c.Data.Datasets[args.ID]
-	if !ok {
-		return nil, nil, errors.New("dataset config not found")
 	}
 
 	delete(c.Data.Datasets, args.ID)
@@ -376,11 +366,6 @@ func (c *MockClusterConf) DeleteService(req *acomm.Request) (interface{}, *url.U
 	}
 	if args.ID == "" {
 		return nil, nil, errors.New("missing arg: id")
-	}
-
-	_, ok := c.Data.Services[args.ID]
-	if !ok {
-		return nil, nil, errors.New("service config not found")
 	}
 
 	delete(c.Data.Services, args.ID)

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -50,7 +50,7 @@ func (c *MockClusterConf) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("list-datasets", c.ListDatasets)
 	server.RegisterTask("update-dataset", c.UpdateDataset)
 	server.RegisterTask("delete-dataset", c.DeleteDataset)
-	server.RegisterTask("dataset-heartbeat", c.DeleteDataset)
+	server.RegisterTask("dataset-heartbeat", c.DatasetHeartbeat)
 	server.RegisterTask("get-default-options", c.GetDefaults)
 	server.RegisterTask("set-default-options", c.UpdateDefaults)
 	server.RegisterTask("node-heartbeat", c.NodeHeartbeat)
@@ -228,6 +228,9 @@ func (c *MockClusterConf) DatasetHeartbeat(req *acomm.Request) (interface{}, *ur
 	dataset, ok := c.Data.Datasets[args.ID]
 	if !ok {
 		return nil, nil, errors.New("dataset config not found")
+	}
+	if dataset.Nodes == nil {
+		dataset.Nodes = make(map[string]bool)
 	}
 	dataset.Nodes[args.IP.String()] = true
 	return &DatasetPayload{dataset}, nil, nil

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -13,8 +13,7 @@ import (
 
 // MockClusterConf is a mock ClusterConf provider.
 type MockClusterConf struct {
-	config *provider.Config
-	Data   *MockClusterData
+	Data *MockClusterData
 }
 
 // MockClusterData is the in-memory data structure for a MockClusterConf.
@@ -28,9 +27,8 @@ type MockClusterData struct {
 }
 
 // NewMockClusterConf creates a new MockClusterConf.
-func NewMockClusterConf(config *provider.Config) *MockClusterConf {
+func NewMockClusterConf() *MockClusterConf {
 	return &MockClusterConf{
-		config: config,
 		Data: &MockClusterData{
 			Services: make(map[string]*Service),
 			Bundles:  make(map[int]*Bundle),

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -3,6 +3,7 @@ package clusterconf
 import (
 	"errors"
 	"math/rand"
+	"net"
 	"net/url"
 	"time"
 
@@ -146,6 +147,9 @@ func (c *MockClusterConf) BundleHeartbeat(req *acomm.Request) (interface{}, *url
 		return nil, nil, errors.New("bundle config not found")
 	}
 
+	if bundle.Nodes == nil {
+		bundle.Nodes = make(map[string]net.IP)
+	}
 	bundle.Nodes[args.Serial] = args.IP
 	return &BundlePayload{bundle}, nil, nil
 }

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -1,0 +1,358 @@
+package clusterconf
+
+import (
+	"errors"
+	"math/rand"
+	"net/url"
+	"time"
+
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/provider"
+	"github.com/pborman/uuid"
+)
+
+type MockClusterConf struct {
+	config *provider.Config
+	Data   *MockClusterData
+}
+
+type MockClusterData struct {
+	bundles  map[int]*Bundle
+	datasets map[string]*Dataset
+	nodes    map[string]*Node
+	history  NodesHistory
+	config   map[string]interface{}
+}
+
+func NewMockClusterConf(config *provider.Config) *MockClusterConf {
+	return &MockClusterData{
+		config: config,
+		Data: &MockClusterData{
+			bundles:  make(map[int]*Bundle),
+			datasets: make(map[string]*Dataset),
+			nodes:    make(map[string]*Node),
+			history:  make(NodesHistory),
+			config:   make(map[string]interface{}),
+		},
+	}
+}
+
+// RegisterTasks registers all of Systemd's task handlers with the server.
+func (c *MockClusterConf) RegisterTasks(server *provider.Server) {
+	server.RegisterTask("get-bundle", c.GetBundle)
+	server.RegisterTask("list-bundles", c.ListBundles)
+	server.RegisterTask("update-bundle", c.UpdateBundle)
+	server.RegisterTask("delete-bundle", c.DeleteBundle)
+	server.RegisterTask("bundle-heartbeat", c.BundleHeartbeat)
+	server.RegisterTask("get-dataset", c.GetDataset)
+	server.RegisterTask("list-datasets", c.ListDatasets)
+	server.RegisterTask("update-dataset", c.UpdateDataset)
+	server.RegisterTask("delete-dataset", c.DeleteDataset)
+	server.RegisterTask("dataset-heartbeat", c.DeleteDataset)
+	server.RegisterTask("get-default-options", c.GetDefaults)
+	server.RegisterTask("set-default-options", c.UpdateDefaults)
+	server.RegisterTask("node-heartbeat", c.NodeHeartbeat)
+	server.RegisterTask("get-node", c.GetNode)
+	server.RegisterTask("get-nodes-history", c.GetNodesHistory)
+	server.RegisterTask("get-service", c.GetService)
+	server.RegisterTask("update-service", c.UpdateService)
+	server.RegisterTask("delete-service", c.DeleteService)
+}
+
+func (c *MockClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args BundleIDArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == 0 {
+		return nil, nil, errors.New("missing arg: id")
+	}
+	bundle, ok := c.Data.Bundles[args.ID]
+	if !ok {
+		return nil, nil, errors.New("bundle config not found")
+	}
+	return &BundlePayload{bundle}, nil, nil
+}
+
+func (c *MockClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error) {
+	bundles := make([]*Bundle, 0, len(c.Data.Bundles))
+	for _, bundle := range c.Data.Bundles {
+		bundles = append(bundles, bundle)
+	}
+	return &BundleListResult{
+		Bundles: bundles,
+	}
+}
+
+func (c *MockClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args BundlePayload
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.Bundle == nil {
+		return nil, nil, errors.New("missing arg: bundle")
+	}
+
+	if args.Bundle.ID == 0 {
+		rand.Seed(time.Now().UnixNano())
+		args.Bundle.ID = rand.Int()
+	}
+
+	args.Bundle.ModIndex++
+	c.Data.Bundles[args.Bundle.ID] = args.Bundle
+	return &BundlePayload{args.Bundle}, nil, nil
+}
+
+func (c *MockClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args BundleIDArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == 0 {
+		return nil, nil, errors.New("missing arg: id")
+	}
+
+	_, ok := c.Data.Bundles[args.ID]
+	if !ok {
+		return nil, nil, errors.New("bundle config not found")
+	}
+
+	delete(c.Data.Bundles, args.ID)
+	return nil, nil, nil
+}
+
+func (c *MockClusterConf) BundleHeartbeat(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args BundleHeartbeatArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == 0 {
+		return nil, nil, errors.New("missing arg: id")
+	}
+	if args.Serial == "" {
+		return nil, nil, errors.New("missing arg: serial")
+	}
+	if args.IP == nil {
+		return nil, nil, errors.New("missing arg: ip")
+	}
+
+	bundle, ok := c.Data.Bundles[args.ID]
+	if !ok {
+		return nil, nil, errors.New("bundle config not found")
+	}
+
+	bundle.Nodes[args.Serial] = args.IP
+	return &BundlePayload{bundle}, nil, nil
+}
+
+func (c *MockClusterConf) GetDataset(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args DatasetIDArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == "" {
+		return nil, nil, errors.New("missing arg: id")
+	}
+	dataset, ok := c.Data.Datasets[args.ID]
+	if !ok {
+		return nil, nil, errors.New("dataset config not found")
+	}
+	return &DatasetPayload{dataset}, nil, nil
+}
+func (c *MockClusterConf) ListDatasets(req *acomm.Request) (interface{}, *url.URL, error) {
+	datasets := make([]*Dataset, 0, len(c.Data.Datasets))
+	for _, dataset := range c.Data.Datasets {
+		datasets = append(datasets, dataset)
+	}
+	return &DatasetListResult{
+		Datasets: datasets,
+	}
+}
+func (c *MockClusterConf) UpdateDataset(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args DatasetPayload
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.Dataset == nil {
+		return nil, nil, errors.New("missing arg: dataset")
+	}
+
+	if args.Dataset.ID == "" {
+		args.Dataset.ID = uuid.New()
+	}
+
+	args.Dataset.ModIndex++
+	c.Data.Datasets[args.Dataset.ID] = args.Dataset
+	return &DatasetPayload{args.Dataset}, nil, nil
+}
+func (c *MockClusterConf) DeleteDataset(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args DatasetIDArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == "" {
+		return nil, nil, errors.New("missing arg: id")
+	}
+
+	_, ok := c.Data.Datasets[args.ID]
+	if !ok {
+		return nil, nil, errors.New("dataset config not found")
+	}
+
+	delete(c.Data.Datasets, args.ID)
+	return nil, nil, nil
+}
+func (c *MockClusterConf) DatasetHeartbeat(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args DatasetHeartbeatArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == "" {
+		return nil, nil, errors.New("missing arg: id")
+	}
+	if args.IP == nil {
+		return nil, nil, errors.New("missing arg: ip")
+	}
+	dataset, ok := c.Data.Datasets[args.ID]
+	if !ok {
+		return nil, nil, errors.New("dataset config not found")
+	}
+	dataset.Nodes[IP.String()] = true
+	return &DatasetPayload{dataset}, nil, nil
+}
+
+func (c *MockClusterConf) GetDefaults(req *acomm.Request) (interface{}, *url.URL, error) {
+	return &DefaultsPayload{c.Data.Defaults}, nil, nil
+}
+
+func (c *MockClusterConf) SetDefaults(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args DefaultsPayload
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.Defaults == nil {
+		return nil, nil, errors.New("missing arg: defaults")
+	}
+
+	args.Defaults.ModIndex++
+	c.Data.Defaults = args.Defaults
+	return &DefaultsPayload{args.Defaults}, nil, nil
+}
+
+func (c *MockClusterConf) NodeHeartbeat(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args NodePayload
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.Node == nil {
+		return nil, nil, errors.New("missing arg: node")
+	}
+
+	c.Data.Nodes[args.Node.ID] = args.Node
+	hbTime := args.Node.Heartbeat.Format(time.RFC3339)
+	history, ok := c.Data.History[args.Node.ID]
+	if ok {
+		history[hbTime] = args.Node
+	} else {
+		c.Data.History[args.Node.ID] = NodesHistory{
+			hbTime: args.Node,
+		}
+	}
+	return nil, nil, nil
+}
+func (c *MockClusterConf) GetNode(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args IDArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == "" {
+		return nil, nil, errors.New("missing arg: id")
+	}
+
+	node, ok := c.Data.Nodes[args.ID]
+	if !ok {
+		return nil, nil, errors.New("node not found")
+	}
+	return &NodePayload{node}, nil, nil
+}
+func (c *MockClusterConf) GetNodesHistory(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args NodeHistoryArgs
+	if err := req.UnmarshalArgs(args); err != nil {
+		return nil, nil, err
+	}
+
+	filters := []nodeFilter{
+		nodeFilterID(args.IDs...),
+		nodeFilterHeartbeat(args.Before, args.After),
+	}
+
+	history := make(NodesHistory)
+	for id, savedNodeHistory := range c.Data.NodesHistory {
+		for _, node := range savedNodeHistory {
+			for _, fn := range filters {
+				if !fn(node) {
+					continue
+				}
+			}
+
+			nodeHistory, ok := history[node.ID]
+			if !ok {
+				nodeHistory = make(NodeHistory)
+				history[node.ID] = nodeHistory
+			}
+			nodeHistory[node.Heartbeat] = node
+		}
+	}
+
+	return &NodesHistoryResult{history}, nil, nil
+}
+
+func (c *MockClusterConf) GetService(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args IDArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == "" {
+		return nil, nil, errors.New("missing arg: id")
+	}
+
+	service, ok := c.Data.Services[args.ID]
+	if !ok {
+		return nil, nil, errors.New("service config not found")
+	}
+	return &ServicePayload{service}, nil, nil
+}
+func (c *MockClusterConf) UpdateService(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args ServicePayload
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.Service == nil {
+		return nil, nil, errors.New("missing arg: service")
+	}
+
+	if args.Service.ID == "" {
+		args.Service.ID = uuid.New()
+	}
+
+	args.Service.ModIndex++
+	c.Data.Services[args.Service.ID] = args.Service
+	return &ServicePayload{args.Service}, nil, nil
+}
+func (c *MockClusterConf) DeleteService(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args ServiceIDArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.ID == "" {
+		return nil, nil, errors.New("missing arg: id")
+	}
+
+	_, ok := c.Data.Services[args.ID]
+	if !ok {
+		return nil, nil, errors.New("service config not found")
+	}
+
+	delete(c.Data.Services, args.ID)
+	return nil, nil, nil
+}

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -11,11 +11,13 @@ import (
 	"github.com/pborman/uuid"
 )
 
+// MockClusterConf is a mock ClusterConf provider.
 type MockClusterConf struct {
 	config *provider.Config
 	Data   *MockClusterData
 }
 
+// MockClusterData is the in-memory data structure for a MockClusterConf.
 type MockClusterData struct {
 	Services map[string]*Service
 	Bundles  map[int]*Bundle
@@ -25,6 +27,7 @@ type MockClusterData struct {
 	Defaults *Defaults
 }
 
+// NewMockClusterConf creates a new MockClusterConf.
 func NewMockClusterConf(config *provider.Config) *MockClusterConf {
 	return &MockClusterConf{
 		config: config,
@@ -38,7 +41,7 @@ func NewMockClusterConf(config *provider.Config) *MockClusterConf {
 	}
 }
 
-// RegisterTasks registers all of Systemd's task handlers with the server.
+// RegisterTasks registers all of MockClusterConf's tasks.
 func (c *MockClusterConf) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("get-bundle", c.GetBundle)
 	server.RegisterTask("list-bundles", c.ListBundles)
@@ -60,6 +63,7 @@ func (c *MockClusterConf) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("delete-service", c.DeleteService)
 }
 
+// GetBundle retrieves a mock bundle.
 func (c *MockClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args BundleIDArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -75,6 +79,7 @@ func (c *MockClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, 
 	return &BundlePayload{bundle}, nil, nil
 }
 
+// ListBundles retrieves all mock bundles.
 func (c *MockClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error) {
 	bundles := make([]*Bundle, 0, len(c.Data.Bundles))
 	for _, bundle := range c.Data.Bundles {
@@ -83,6 +88,7 @@ func (c *MockClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL
 	return &BundleListResult{bundles}, nil, nil
 }
 
+// UpdateBundle updates a mock bundle.
 func (c *MockClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args BundlePayload
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -102,6 +108,7 @@ func (c *MockClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.UR
 	return &BundlePayload{args.Bundle}, nil, nil
 }
 
+// DeleteBundle removes a mock bundle.
 func (c *MockClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args BundleIDArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -120,6 +127,7 @@ func (c *MockClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.UR
 	return nil, nil, nil
 }
 
+// BundleHeartbeat adds a mock bundle heartbeat.
 func (c *MockClusterConf) BundleHeartbeat(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args BundleHeartbeatArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -144,6 +152,7 @@ func (c *MockClusterConf) BundleHeartbeat(req *acomm.Request) (interface{}, *url
 	return &BundlePayload{bundle}, nil, nil
 }
 
+// GetDataset retrieves a mock dataset.
 func (c *MockClusterConf) GetDataset(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args IDArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -158,6 +167,8 @@ func (c *MockClusterConf) GetDataset(req *acomm.Request) (interface{}, *url.URL,
 	}
 	return &DatasetPayload{dataset}, nil, nil
 }
+
+// ListDatasets lists all mock datasets.
 func (c *MockClusterConf) ListDatasets(req *acomm.Request) (interface{}, *url.URL, error) {
 	datasets := make([]*Dataset, 0, len(c.Data.Datasets))
 	for _, dataset := range c.Data.Datasets {
@@ -165,6 +176,8 @@ func (c *MockClusterConf) ListDatasets(req *acomm.Request) (interface{}, *url.UR
 	}
 	return &DatasetListResult{datasets}, nil, nil
 }
+
+// UpdateDataset updates a mock dataset.
 func (c *MockClusterConf) UpdateDataset(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args DatasetPayload
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -182,6 +195,8 @@ func (c *MockClusterConf) UpdateDataset(req *acomm.Request) (interface{}, *url.U
 	c.Data.Datasets[args.Dataset.ID] = args.Dataset
 	return &DatasetPayload{args.Dataset}, nil, nil
 }
+
+// DeleteDataset removes a mock dataset.
 func (c *MockClusterConf) DeleteDataset(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args IDArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -199,6 +214,8 @@ func (c *MockClusterConf) DeleteDataset(req *acomm.Request) (interface{}, *url.U
 	delete(c.Data.Datasets, args.ID)
 	return nil, nil, nil
 }
+
+// DatasetHeartbeat adds a mock dataset heartbeat.
 func (c *MockClusterConf) DatasetHeartbeat(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args DatasetHeartbeatArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -218,10 +235,12 @@ func (c *MockClusterConf) DatasetHeartbeat(req *acomm.Request) (interface{}, *ur
 	return &DatasetPayload{dataset}, nil, nil
 }
 
+// GetDefaults retrieves the mock default values.
 func (c *MockClusterConf) GetDefaults(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &DefaultsPayload{c.Data.Defaults}, nil, nil
 }
 
+// UpdateDefaults updates the mock default values.
 func (c *MockClusterConf) UpdateDefaults(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args DefaultsPayload
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -236,6 +255,7 @@ func (c *MockClusterConf) UpdateDefaults(req *acomm.Request) (interface{}, *url.
 	return &DefaultsPayload{args.Defaults}, nil, nil
 }
 
+// NodeHeartbeat adds a mock node heartbeat.
 func (c *MockClusterConf) NodeHeartbeat(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args NodePayload
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -256,6 +276,8 @@ func (c *MockClusterConf) NodeHeartbeat(req *acomm.Request) (interface{}, *url.U
 	}
 	return nil, nil, nil
 }
+
+// GetNode retrieves a mock node.
 func (c *MockClusterConf) GetNode(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args IDArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -271,6 +293,8 @@ func (c *MockClusterConf) GetNode(req *acomm.Request) (interface{}, *url.URL, er
 	}
 	return &NodePayload{node}, nil, nil
 }
+
+// GetNodesHistory retrieves mock nodes history.
 func (c *MockClusterConf) GetNodesHistory(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args NodeHistoryArgs
 	if err := req.UnmarshalArgs(args); err != nil {
@@ -303,6 +327,7 @@ func (c *MockClusterConf) GetNodesHistory(req *acomm.Request) (interface{}, *url
 	return &NodesHistoryResult{history}, nil, nil
 }
 
+// GetService retrieves a mock service.
 func (c *MockClusterConf) GetService(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args IDArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -318,6 +343,8 @@ func (c *MockClusterConf) GetService(req *acomm.Request) (interface{}, *url.URL,
 	}
 	return &ServicePayload{service}, nil, nil
 }
+
+// UpdateService updates a mock service.
 func (c *MockClusterConf) UpdateService(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args ServicePayload
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -335,6 +362,8 @@ func (c *MockClusterConf) UpdateService(req *acomm.Request) (interface{}, *url.U
 	c.Data.Services[args.Service.ID] = args.Service
 	return &ServicePayload{args.Service}, nil, nil
 }
+
+// DeleteService removes a mock service.
 func (c *MockClusterConf) DeleteService(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args IDArgs
 	if err := req.UnmarshalArgs(&args); err != nil {

--- a/providers/clusterconf/node.go
+++ b/providers/clusterconf/node.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cerana/cerana/acomm"
+	"github.com/shirou/gopsutil/load"
 )
 
 const (
@@ -19,14 +20,14 @@ const (
 // Node is current information about a hardware node.
 type Node struct {
 	c           *ClusterConf
-	ID          string    `json:"id"`
-	Heartbeat   time.Time `json:"heartbeat"`
-	MemoryTotal int64     `json:"memoryTotal"`
-	MemoryFree  int64     `json:"memoryFree"`
-	CPUTotal    int       `json:"cpuTotal"`
-	CPUFree     int       `json:"cpuFree"`
-	DiskTotal   int       `json:"diskTotal"`
-	DiskFree    int       `json:"diskFree"`
+	ID          string       `json:"id"`
+	Heartbeat   time.Time    `json:"heartbeat"`
+	MemoryTotal uint64       `json:"memoryTotal"`
+	MemoryFree  uint64       `json:"memoryFree"`
+	CPUCores    int          `json:"cpuCores"`
+	CPULoad     load.AvgStat `json:"cpuLoad"`
+	DiskTotal   uint64       `json:"diskTotal"`
+	DiskFree    uint64       `json:"diskFree"`
 }
 
 // NodeHistory is a set of historical information for a node.

--- a/providers/clusterconf/node.go
+++ b/providers/clusterconf/node.go
@@ -31,7 +31,7 @@ type Node struct {
 }
 
 // NodeHistory is a set of historical information for a node.
-type NodeHistory map[time.Time]Node
+type NodeHistory map[time.Time]*Node
 
 // NodesHistory is the historical information for multiple nodes.
 type NodesHistory map[string]NodeHistory
@@ -51,7 +51,7 @@ type NodePayload struct {
 
 // NodesHistoryResult is the result from the GetNodesHistory handler.
 type NodesHistoryResult struct {
-	History *NodesHistory `json:"history"`
+	History NodesHistory `json:"history"`
 }
 
 type nodeFilter func(Node) bool
@@ -98,7 +98,7 @@ func (c *ClusterConf) GetNodesHistory(req *acomm.Request) (interface{}, *url.URL
 	if err != nil {
 		return nil, nil, err
 	}
-	return &NodesHistoryResult{history}, nil, nil
+	return &NodesHistoryResult{*history}, nil, nil
 
 }
 
@@ -163,7 +163,7 @@ func (c *ClusterConf) getNodesHistory(filters ...nodeFilter) (*NodesHistory, err
 			nodeHistory = make(NodeHistory)
 			history[node.ID] = nodeHistory
 		}
-		nodeHistory[node.Heartbeat] = node
+		nodeHistory[node.Heartbeat] = &node
 	}
 
 	return &history, nil

--- a/providers/clusterconf/service.go
+++ b/providers/clusterconf/service.go
@@ -99,6 +99,9 @@ func (c *ClusterConf) DeleteService(req *acomm.Request) (interface{}, *url.URL, 
 
 	service, err := c.getService(args.ID)
 	if err != nil {
+		if err.Error() == "service config not found" {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 

--- a/providers/clusterconf/service_test.go
+++ b/providers/clusterconf/service_test.go
@@ -104,7 +104,7 @@ func (s *clusterConf) TestDeleteService() {
 		err string
 	}{
 		{"", "missing arg: id"},
-		{"does-not-exist", "service config not found"},
+		{"does-not-exist", ""},
 		{service.ID, ""},
 	}
 

--- a/providers/metrics/README.md
+++ b/providers/metrics/README.md
@@ -98,6 +98,87 @@ func (m *Metrics) RegisterTasks(server *provider.Server)
 ```
 RegisterTasks registers all of Metric's task handlers with the server.
 
+#### type MockMetrics
+
+```go
+type MockMetrics struct {
+	Data *MockMetricsData
+}
+```
+
+MockMetrics is a mock Metrics provider.
+
+#### func  NewMockMetrics
+
+```go
+func NewMockMetrics() *MockMetrics
+```
+NewMockMetrics creates a new MockMetrics and populates default data.
+
+#### func (*MockMetrics) CPU
+
+```go
+func (m *MockMetrics) CPU(req *acomm.Request) (interface{}, *url.URL, error)
+```
+CPU returns mock CPU information.
+
+#### func (*MockMetrics) Disk
+
+```go
+func (m *MockMetrics) Disk(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Disk returns mock disk information.
+
+#### func (*MockMetrics) Hardware
+
+```go
+func (m *MockMetrics) Hardware(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Hardware returns mock hardware information.
+
+#### func (*MockMetrics) Host
+
+```go
+func (m *MockMetrics) Host(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Host returns mock host information.
+
+#### func (*MockMetrics) Memory
+
+```go
+func (m *MockMetrics) Memory(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Memory returns mock memory information.
+
+#### func (*MockMetrics) Network
+
+```go
+func (m *MockMetrics) Network(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Network returns mock network information.
+
+#### func (*MockMetrics) RegisterTasks
+
+```go
+func (m *MockMetrics) RegisterTasks(server *provider.Server)
+```
+RegisterTasks registes all MockMetric task handlers.
+
+#### type MockMetricsData
+
+```go
+type MockMetricsData struct {
+	CPU      *CPUResult
+	Disk     *DiskResult
+	Hardware interface{}
+	Host     *host.InfoStat
+	Memory   *MemoryResult
+	Network  *NetworkResult
+}
+```
+
+MockMetricsData is the in-memory data structure for the MockMetrics.
+
 #### type NetworkResult
 
 ```go

--- a/providers/metrics/README.md
+++ b/providers/metrics/README.md
@@ -11,7 +11,7 @@
 ```go
 type CPUResult struct {
 	Info  []cpu.InfoStat  `json:"info"`
-	Load  *load.AvgStat   `json:"load"`
+	Load  load.AvgStat    `json:"load"`
 	Times []cpu.TimesStat `json:"times"`
 }
 ```

--- a/providers/metrics/cpu.go
+++ b/providers/metrics/cpu.go
@@ -11,7 +11,7 @@ import (
 // CPUResult is the result of the CPU handler.
 type CPUResult struct {
 	Info  []cpu.InfoStat  `json:"info"`
-	Load  *load.AvgStat   `json:"load"`
+	Load  load.AvgStat    `json:"load"`
 	Times []cpu.TimesStat `json:"times"`
 }
 
@@ -32,5 +32,5 @@ func (m *Metrics) CPU(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, err
 	}
 
-	return &CPUResult{Info: info, Load: loadAvg, Times: times}, nil, nil
+	return &CPUResult{Info: info, Load: *loadAvg, Times: times}, nil, nil
 }

--- a/providers/metrics/mock.go
+++ b/providers/metrics/mock.go
@@ -100,7 +100,16 @@ func NewMockMetrics() *MockMetrics {
 			Disk: &DiskResult{
 				IO:         make(map[string]disk.IOCountersStat),
 				Partitions: []disk.PartitionStat{},
-				Usage:      []*disk.UsageStat{},
+				Usage: []*disk.UsageStat{
+					{
+						Path:        "/",
+						Fstype:      "zfs",
+						Total:       100000,
+						Free:        50000,
+						Used:        50000,
+						UsedPercent: 0.5,
+					},
+				},
 			},
 			Hardware: struct{}{},
 			Host: &host.InfoStat{

--- a/providers/metrics/mock.go
+++ b/providers/metrics/mock.go
@@ -1,0 +1,186 @@
+package metrics
+
+import (
+	"net/url"
+
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/provider"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/net"
+)
+
+// MockMetrics is a mock Metrics provider.
+type MockMetrics struct {
+	Data *MockMetricsData
+}
+
+// MockMetricsData is the in-memory data structure for the MockMetrics.
+type MockMetricsData struct {
+	CPU      *CPUResult
+	Disk     *DiskResult
+	Hardware interface{}
+	Host     *host.InfoStat
+	Memory   *MemoryResult
+	Network  *NetworkResult
+}
+
+// NewMockMetrics creates a new MockMetrics and populates default data.
+func NewMockMetrics() *MockMetrics {
+	return &MockMetrics{
+		Data: &MockMetricsData{
+			CPU: &CPUResult{
+				Info: []cpu.InfoStat{
+					{
+						CPU:        0,
+						VendorID:   "",
+						Family:     "6",
+						Model:      "69",
+						Stepping:   1,
+						PhysicalID: "0",
+						CoreID:     "0",
+						Cores:      1,
+						ModelName:  "Intel(R) Core(TM) i5-4278U CPU @ 2.60GHz",
+						Mhz:        2599.79,
+						CacheSize:  3072,
+						Flags:      []string{},
+					}, {
+						CPU:        1,
+						VendorID:   "",
+						Family:     "6",
+						Model:      "69",
+						Stepping:   1,
+						PhysicalID: "0",
+						CoreID:     "1",
+						Cores:      1,
+						ModelName:  "Intel(R) Core(TM) i5-4278U CPU @ 2.60GHz",
+						Mhz:        2599.79,
+						CacheSize:  3072,
+						Flags:      []string{},
+					},
+				},
+				Load: load.AvgStat{
+					Load1:  0.72,
+					Load5:  0.22,
+					Load15: 0.11,
+				},
+				Times: []cpu.TimesStat{
+					{
+						CPU:       "cpu0",
+						User:      4973.34,
+						System:    3579.08,
+						Idle:      824805.64,
+						Nice:      0.93,
+						Iowait:    921.25,
+						Irq:       0,
+						Softirq:   674.86,
+						Steal:     0,
+						Guest:     0,
+						GuestNice: 0,
+						Stolen:    0,
+					}, {
+						CPU:       "cpu1",
+						User:      5104.66,
+						System:    3458.4,
+						Idle:      837419.2,
+						Nice:      1.29,
+						Iowait:    869.55,
+						Irq:       0,
+						Softirq:   161.14,
+						Steal:     0,
+						Guest:     0,
+						GuestNice: 0,
+						Stolen:    0,
+					},
+				},
+			},
+			Disk: &DiskResult{
+				IO:         make(map[string]disk.IOCountersStat),
+				Partitions: []disk.PartitionStat{},
+				Usage:      []*disk.UsageStat{},
+			},
+			Hardware: struct{}{},
+			Host: &host.InfoStat{
+				Hostname:       "mockMetrics",
+				Uptime:         uint64(123456),
+				BootTime:       uint64(123456),
+				Procs:          5,
+				OS:             "linux",
+				Platform:       "cerana",
+				PlatformFamily: "nix",
+			},
+			Memory: &MemoryResult{
+				Swap: &mem.SwapMemoryStat{
+					Total:       100000,
+					Used:        50000,
+					Free:        50000,
+					UsedPercent: 0.5,
+				},
+				Virtual: &mem.VirtualMemoryStat{
+					Total:       100000,
+					Available:   100000,
+					Used:        50000,
+					Free:        50000,
+					UsedPercent: 0.5,
+				},
+			},
+			Network: &NetworkResult{
+				IO: []net.IOCountersStat{
+					net.IOCountersStat{
+						Name:        "fooIface",
+						BytesSent:   12345,
+						BytesRecv:   54321,
+						PacketsSent: 12345,
+						PacketsRecv: 54321,
+					},
+				},
+				Interfaces: []net.InterfaceStat{
+					net.InterfaceStat{
+						Name:         "fooIface",
+						MTU:          1500,
+						HardwareAddr: "en0",
+						Addrs: []net.InterfaceAddr{
+							net.InterfaceAddr{"123.123.123.123"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// RegisterTasks registes all MockMetric task handlers.
+func (m *MockMetrics) RegisterTasks(server *provider.Server) {
+	server.RegisterTask("metrics-cpu", m.CPU)
+	server.RegisterTask("metrics-disk", m.Disk)
+	server.RegisterTask("metrics-host", m.Host)
+	server.RegisterTask("metrics-memory", m.Memory)
+	server.RegisterTask("metrics-network", m.Network)
+}
+
+func (m *MockMetrics) CPU(req *acomm.Request) (interface{}, *url.URL, error) {
+	return m.Data.CPU, nil, nil
+}
+
+func (m *MockMetrics) Disk(req *acomm.Request) (interface{}, *url.URL, error) {
+	return m.Data.Disk, nil, nil
+}
+
+func (m *MockMetrics) Hardware(req *acomm.Request) (interface{}, *url.URL, error) {
+	return m.Data.Hardware, nil, nil
+}
+
+func (m *MockMetrics) Host(req *acomm.Request) (interface{}, *url.URL, error) {
+	return m.Data.Host, nil, nil
+}
+
+func (m *MockMetrics) Memory(req *acomm.Request) (interface{}, *url.URL, error) {
+	return m.Data.Memory, nil, nil
+}
+
+func (m *MockMetrics) Network(req *acomm.Request) (interface{}, *url.URL, error) {
+	return m.Data.Network, nil, nil
+}

--- a/providers/metrics/mock.go
+++ b/providers/metrics/mock.go
@@ -138,7 +138,7 @@ func NewMockMetrics() *MockMetrics {
 			},
 			Network: &NetworkResult{
 				IO: []net.IOCountersStat{
-					net.IOCountersStat{
+					{
 						Name:        "fooIface",
 						BytesSent:   12345,
 						BytesRecv:   54321,
@@ -147,12 +147,12 @@ func NewMockMetrics() *MockMetrics {
 					},
 				},
 				Interfaces: []net.InterfaceStat{
-					net.InterfaceStat{
+					{
 						Name:         "fooIface",
 						MTU:          1500,
 						HardwareAddr: "en0",
 						Addrs: []net.InterfaceAddr{
-							net.InterfaceAddr{"123.123.123.123"},
+							{"123.123.123.123"},
 						},
 					},
 				},
@@ -170,26 +170,32 @@ func (m *MockMetrics) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("metrics-network", m.Network)
 }
 
+// CPU returns mock CPU information.
 func (m *MockMetrics) CPU(req *acomm.Request) (interface{}, *url.URL, error) {
 	return m.Data.CPU, nil, nil
 }
 
+// Disk returns mock disk information.
 func (m *MockMetrics) Disk(req *acomm.Request) (interface{}, *url.URL, error) {
 	return m.Data.Disk, nil, nil
 }
 
+// Hardware returns mock hardware information.
 func (m *MockMetrics) Hardware(req *acomm.Request) (interface{}, *url.URL, error) {
 	return m.Data.Hardware, nil, nil
 }
 
+// Host returns mock host information.
 func (m *MockMetrics) Host(req *acomm.Request) (interface{}, *url.URL, error) {
 	return m.Data.Host, nil, nil
 }
 
+// Memory returns mock memory information.
 func (m *MockMetrics) Memory(req *acomm.Request) (interface{}, *url.URL, error) {
 	return m.Data.Memory, nil, nil
 }
 
+// Network returns mock network information.
 func (m *MockMetrics) Network(req *acomm.Request) (interface{}, *url.URL, error) {
 	return m.Data.Network, nil, nil
 }

--- a/providers/systemd/README.md
+++ b/providers/systemd/README.md
@@ -141,6 +141,104 @@ type ListResult struct {
 
 ListResult is the result of the List handler.
 
+#### type MockSystemd
+
+```go
+type MockSystemd struct {
+	Data *MockSystemdData
+}
+```
+
+MockSystemd is a mock version of the Systemd provider.
+
+#### func  NewMockSystemd
+
+```go
+func NewMockSystemd() *MockSystemd
+```
+NewMockSystemd creates a new MockSystemd.
+
+#### func (*MockSystemd) Create
+
+```go
+func (s *MockSystemd) Create(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Create creates a mock unit file.
+
+#### func (*MockSystemd) Disable
+
+```go
+func (s *MockSystemd) Disable(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Disable disables a mock service.
+
+#### func (*MockSystemd) Enable
+
+```go
+func (s *MockSystemd) Enable(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Enable enables a mock service.
+
+#### func (*MockSystemd) Get
+
+```go
+func (s *MockSystemd) Get(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Get retrieves a mock service.
+
+#### func (*MockSystemd) List
+
+```go
+func (s *MockSystemd) List(req *acomm.Request) (interface{}, *url.URL, error)
+```
+List lists mock services.
+
+#### func (*MockSystemd) RegisterTasks
+
+```go
+func (s *MockSystemd) RegisterTasks(server *provider.Server)
+```
+RegisterTasks registers the MockSystemd tasks.
+
+#### func (*MockSystemd) Remove
+
+```go
+func (s *MockSystemd) Remove(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Remove removes a mock unit file.
+
+#### func (*MockSystemd) Restart
+
+```go
+func (s *MockSystemd) Restart(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Restart restarts a mock service.
+
+#### func (*MockSystemd) Start
+
+```go
+func (s *MockSystemd) Start(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Start starts a mock service.
+
+#### func (*MockSystemd) Stop
+
+```go
+func (s *MockSystemd) Stop(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Stop stops a mock service.
+
+#### type MockSystemdData
+
+```go
+type MockSystemdData struct {
+	Statuses  map[string]dbus.UnitStatus
+	UnitFiles map[string]bool
+}
+```
+
+MockSystemdData is the in-memory data structure for the MockSystemd.
+
 #### type RemoveArgs
 
 ```go

--- a/providers/systemd/mock.go
+++ b/providers/systemd/mock.go
@@ -119,7 +119,7 @@ func (s *MockSystemd) Get(req *acomm.Request) (interface{}, *url.URL, error) {
 // List lists mock services.
 func (s *MockSystemd) List(req *acomm.Request) (interface{}, *url.URL, error) {
 	list := make([]dbus.UnitStatus, 0, len(s.Data.Statuses))
-	for _, status := range list {
+	for _, status := range s.Data.Statuses {
 		list = append(list, status)
 	}
 	return &ListResult{list}, nil, nil

--- a/providers/systemd/mock.go
+++ b/providers/systemd/mock.go
@@ -11,8 +11,7 @@ import (
 
 // MockSystemd is a mock version of the Systemd provider.
 type MockSystemd struct {
-	config *provider.Config
-	Data   *MockSystemdData
+	Data *MockSystemdData
 }
 
 // MockSystemdData is the in-memory data structure for the MockSystemd.
@@ -22,9 +21,12 @@ type MockSystemdData struct {
 }
 
 // NewMockSystemd creates a new MockSystemd.
-func NewMockSystemd(config *provider.Config) *MockSystemd {
+func NewMockSystemd() *MockSystemd {
 	return &MockSystemd{
-		config: config,
+		Data: &MockSystemdData{
+			Statuses:  make(map[string]dbus.UnitStatus),
+			UnitFiles: make(map[string]bool),
+		},
 	}
 }
 

--- a/providers/systemd/mock.go
+++ b/providers/systemd/mock.go
@@ -9,22 +9,26 @@ import (
 	"github.com/coreos/go-systemd/dbus"
 )
 
+// MockSystemd is a mock version of the Systemd provider.
 type MockSystemd struct {
 	config *provider.Config
 	Data   *MockSystemdData
 }
 
+// MockSystemdData is the in-memory data structure for the MockSystemd.
 type MockSystemdData struct {
 	Statuses  map[string]dbus.UnitStatus
 	UnitFiles map[string]bool
 }
 
+// NewMockSystemd creates a new MockSystemd.
 func NewMockSystemd(config *provider.Config) *MockSystemd {
 	return &MockSystemd{
 		config: config,
 	}
 }
 
+// RegisterTasks registers the MockSystemd tasks.
 func (s *MockSystemd) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("systemd-create", s.Create)
 	server.RegisterTask("systemd-disable", s.Disable)
@@ -37,6 +41,7 @@ func (s *MockSystemd) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("systemd-stop", s.Stop)
 }
 
+// Create creates a mock unit file.
 func (s *MockSystemd) Create(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CreateArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -54,6 +59,7 @@ func (s *MockSystemd) Create(req *acomm.Request) (interface{}, *url.URL, error) 
 	return nil, nil, nil
 }
 
+// Disable disables a mock service.
 func (s *MockSystemd) Disable(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args DisableArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -68,6 +74,7 @@ func (s *MockSystemd) Disable(req *acomm.Request) (interface{}, *url.URL, error)
 	return nil, nil, nil
 }
 
+// Enable enables a mock service.
 func (s *MockSystemd) Enable(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args EnableArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -89,6 +96,7 @@ func (s *MockSystemd) Enable(req *acomm.Request) (interface{}, *url.URL, error) 
 	return nil, nil, nil
 }
 
+// Get retrieves a mock service.
 func (s *MockSystemd) Get(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args GetArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -106,6 +114,7 @@ func (s *MockSystemd) Get(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &GetResult{status}, nil, nil
 }
 
+// List lists mock services.
 func (s *MockSystemd) List(req *acomm.Request) (interface{}, *url.URL, error) {
 	list := make([]dbus.UnitStatus, 0, len(s.Data.Statuses))
 	for _, status := range list {
@@ -114,6 +123,7 @@ func (s *MockSystemd) List(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &ListResult{list}, nil, nil
 }
 
+// Remove removes a mock unit file.
 func (s *MockSystemd) Remove(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args RemoveArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -146,14 +156,17 @@ func (s *MockSystemd) action(req *acomm.Request) (interface{}, *url.URL, error) 
 	return nil, nil, nil
 }
 
+// Restart restarts a mock service.
 func (s *MockSystemd) Restart(req *acomm.Request) (interface{}, *url.URL, error) {
 	return s.action(req)
 }
 
+// Start starts a mock service.
 func (s *MockSystemd) Start(req *acomm.Request) (interface{}, *url.URL, error) {
 	return s.action(req)
 }
 
+// Stop stops a mock service.
 func (s *MockSystemd) Stop(req *acomm.Request) (interface{}, *url.URL, error) {
 	return s.action(req)
 }

--- a/providers/systemd/mock.go
+++ b/providers/systemd/mock.go
@@ -136,9 +136,7 @@ func (s *MockSystemd) Remove(req *acomm.Request) (interface{}, *url.URL, error) 
 		return nil, nil, errors.New("missing arg: name")
 	}
 
-	if _, ok := s.Data.Statuses[args.Name]; !ok {
-		return nil, nil, errors.New("unit not found")
-	}
+	delete(s.Data.Statuses, args.Name)
 	return nil, nil, nil
 }
 

--- a/providers/systemd/mock.go
+++ b/providers/systemd/mock.go
@@ -1,0 +1,159 @@
+package systemd
+
+import (
+	"errors"
+	"net/url"
+
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/provider"
+	"github.com/coreos/go-systemd/dbus"
+)
+
+type MockSystemd struct {
+	config *provider.Config
+	Data   *MockSystemdData
+}
+
+type MockSystemdData struct {
+	Statuses  map[string]dbus.UnitStatus
+	UnitFiles map[string]bool
+}
+
+func NewMockSystemd(config *provider.Config) *MockSystemd {
+	return &MockSystemd{
+		config: config,
+	}
+}
+
+func (s *MockSystemd) RegisterTasks(server *provider.Server) {
+	server.RegisterTask("systemd-create", s.Create)
+	server.RegisterTask("systemd-disable", s.Disable)
+	server.RegisterTask("systemd-enable", s.Enable)
+	server.RegisterTask("systemd-get", s.Get)
+	server.RegisterTask("systemd-list", s.List)
+	server.RegisterTask("systemd-remove", s.Remove)
+	server.RegisterTask("systemd-restart", s.Restart)
+	server.RegisterTask("systemd-start", s.Start)
+	server.RegisterTask("systemd-stop", s.Stop)
+}
+
+func (s *MockSystemd) Create(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CreateArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	if _, ok := s.Data.UnitFiles[args.Name]; ok {
+		return nil, nil, errors.New("unit file already exists")
+	}
+	s.Data.UnitFiles[args.Name] = true
+	return nil, nil, nil
+}
+
+func (s *MockSystemd) Disable(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args DisableArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	delete(s.Data.Statuses, args.Name)
+	return nil, nil, nil
+}
+
+func (s *MockSystemd) Enable(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args EnableArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	if _, ok := s.Data.UnitFiles[args.Name]; !ok {
+		return nil, nil, errors.New("No such file or directory")
+	}
+
+	s.Data.Statuses[args.Name] = dbus.UnitStatus{
+		Name:      args.Name,
+		LoadState: "Loaded",
+	}
+	return nil, nil, nil
+}
+
+func (s *MockSystemd) Get(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args GetArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	status, ok := s.Data.Statuses[args.Name]
+	if !ok {
+		return nil, nil, errors.New("No such file or directory")
+	}
+	return &GetResult{status}, nil, nil
+}
+
+func (s *MockSystemd) List(req *acomm.Request) (interface{}, *url.URL, error) {
+	list := make([]dbus.UnitStatus, 0, len(s.Data.Statuses))
+	for _, status := range list {
+		list = append(list, status)
+	}
+	return &ListResult{list}, nil, nil
+}
+
+func (s *MockSystemd) Remove(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args RemoveArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	if _, ok := s.Data.Statuses[args.Name]; !ok {
+		return nil, nil, errors.New("unit not found")
+	}
+	return nil, nil, nil
+}
+
+func (s *MockSystemd) action(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args ActionArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	if _, ok := s.Data.Statuses[args.Name]; !ok {
+		return nil, nil, errors.New("unit not found")
+	}
+	return nil, nil, nil
+}
+
+func (s *MockSystemd) Restart(req *acomm.Request) (interface{}, *url.URL, error) {
+	return s.action(req)
+}
+
+func (s *MockSystemd) Start(req *acomm.Request) (interface{}, *url.URL, error) {
+	return s.action(req)
+}
+
+func (s *MockSystemd) Stop(req *acomm.Request) (interface{}, *url.URL, error) {
+	return s.action(req)
+}

--- a/providers/systemd/remove.go
+++ b/providers/systemd/remove.go
@@ -29,5 +29,8 @@ func (s *Systemd) Remove(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, err
 	}
 
-	return nil, nil, os.Remove(unitFilePath)
+	if err := os.Remove(unitFilePath); err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
+	}
+	return nil, nil, nil
 }

--- a/providers/systemd/remove_test.go
+++ b/providers/systemd/remove_test.go
@@ -15,7 +15,7 @@ func (s *systemd) TestRemove() {
 		err   string
 	}{
 		{"", false, "missing arg: name"},
-		{"foo", false, fmt.Sprintf("remove %s: no such file or directory", s.dir+"/foo")},
+		{"foo", false, ""},
 		{"foo", true, ""},
 		{".", false, "invalid name"},
 	}

--- a/providers/zfs/README.md
+++ b/providers/zfs/README.md
@@ -130,6 +130,139 @@ type ListResult struct {
 
 ListResult is the result data for the List handler.
 
+#### type MockZFS
+
+```go
+type MockZFS struct {
+	Data *MockZFSData
+}
+```
+
+MockZFS is a mock ZFS provider.
+
+#### func  NewMockZFS
+
+```go
+func NewMockZFS(config *provider.Config, tracker *acomm.Tracker) *MockZFS
+```
+NewMockZFS creates a new instance of MockZFS.
+
+#### func (*MockZFS) Clone
+
+```go
+func (z *MockZFS) Clone(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Clone clones a mock dataset.
+
+#### func (*MockZFS) Create
+
+```go
+func (z *MockZFS) Create(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Create creats a mock dataset.
+
+#### func (*MockZFS) Destroy
+
+```go
+func (z *MockZFS) Destroy(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Destroy destroys a mock dataset.
+
+#### func (*MockZFS) Exists
+
+```go
+func (z *MockZFS) Exists(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Exists checks whether a mock dataset exists.
+
+#### func (*MockZFS) Get
+
+```go
+func (z *MockZFS) Get(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Get retrieves a mock dataset.
+
+#### func (*MockZFS) Holds
+
+```go
+func (z *MockZFS) Holds(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Holds retrieves a mock dataset's holds.
+
+#### func (*MockZFS) List
+
+```go
+func (z *MockZFS) List(req *acomm.Request) (interface{}, *url.URL, error)
+```
+List returns all mock datasets.
+
+#### func (*MockZFS) Mount
+
+```go
+func (z *MockZFS) Mount(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Mount mounts a mock dataset.
+
+#### func (*MockZFS) Receive
+
+```go
+func (z *MockZFS) Receive(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Receive receives mock dataset data and creates a mock dataset.
+
+#### func (*MockZFS) RegisterTasks
+
+```go
+func (z *MockZFS) RegisterTasks(server *provider.Server)
+```
+RegisterTasks registers all MockZFS tasks.
+
+#### func (*MockZFS) Rename
+
+```go
+func (z *MockZFS) Rename(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Rename renames a mock dataset.
+
+#### func (*MockZFS) Rollback
+
+```go
+func (z *MockZFS) Rollback(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Rollback rolls back to a mock dataset.
+
+#### func (*MockZFS) Send
+
+```go
+func (z *MockZFS) Send(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Send sends mock dataset data.
+
+#### func (*MockZFS) Snapshot
+
+```go
+func (z *MockZFS) Snapshot(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Snapshot snapshots a mock dataset.
+
+#### func (*MockZFS) Unmount
+
+```go
+func (z *MockZFS) Unmount(req *acomm.Request) (interface{}, *url.URL, error)
+```
+Unmount unmounts a mock dataset.
+
+#### type MockZFSData
+
+```go
+type MockZFSData struct {
+	Datasets map[string]*Dataset
+	Data     map[string][]byte
+}
+```
+
+MockZFSData is the in-memory data structure for the MockZFS.
+
 #### type MountArgs
 
 ```go

--- a/providers/zfs/mock.go
+++ b/providers/zfs/mock.go
@@ -1,0 +1,352 @@
+package zfs
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/url"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/logrusx"
+	"github.com/cerana/cerana/provider"
+	"github.com/cerana/cerana/zfs"
+)
+
+type MockZFS struct {
+	config  *provider.Config
+	tracker *acomm.Tracker
+	Data    *MockZFSData
+}
+
+type MockZFSData struct {
+	Datasets map[string]*Dataset
+	Data     map[string][]byte
+}
+
+func NewMockZFS(config *provider.Config, tracker *acomm.Tracker) *MockZFS {
+	return &MockZFS{
+		config:  config,
+		tracker: tracker,
+		Data: &MockZFSData{
+			Datasets: make(map[string]*Dataset),
+			Data:     make(map[string][]byte),
+		},
+	}
+}
+
+func (z *MockZFS) RegisterTasks(server *provider.Server) {
+	server.RegisterTask("zfs-clone", z.Clone)
+	server.RegisterTask("zfs-create", z.Create)
+	server.RegisterTask("zfs-destroy", z.Destroy)
+	server.RegisterTask("zfs-exists", z.Exists)
+	server.RegisterTask("zfs-get", z.Get)
+	server.RegisterTask("zfs-holds", z.Holds)
+	server.RegisterTask("zfs-list", z.List)
+	server.RegisterTask("zfs-mount", z.Mount)
+	server.RegisterTask("zfs-receive", z.Receive)
+	server.RegisterTask("zfs-rename", z.Rename)
+	server.RegisterTask("zfs-rollback", z.Rollback)
+	server.RegisterTask("zfs-send", z.Send)
+	server.RegisterTask("zfs-snapshot", z.Snapshot)
+	server.RegisterTask("zfs-unmount", z.Unmount)
+}
+
+func (z *MockZFS) Clone(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CloneArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+	if args.Origin == "" {
+		return nil, nil, errors.New("missing arg: origin")
+	}
+	if err := fixPropertyTypesFromJSON(args.Properties); err != nil {
+		return nil, nil, err
+	}
+
+	origin, ok := z.Data.Datasets[args.Origin]
+	if !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+	*z.Data.Datasets[args.Name] = *origin
+	z.Data.Datasets[args.Name].Name = args.Name
+	z.Data.Datasets[args.Name].Properties.Origin = args.Origin
+	return &DatasetResult{z.Data.Datasets[args.Name]}, nil, nil
+}
+
+func (z *MockZFS) Create(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CreateArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	if err := fixPropertyTypesFromJSON(args.Properties); err != nil {
+		return nil, nil, err
+	}
+	_, ok := z.Data.Datasets[args.Name]
+	if ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+
+	z.Data.Datasets[args.Name] = &Dataset{
+		Name: args.Name,
+		Properties: &zfs.DatasetProperties{
+			Type:    args.Type,
+			Volsize: args.Volsize,
+		},
+	}
+	return &DatasetResult{z.Data.Datasets[args.Name]}, nil, nil
+}
+
+func (z *MockZFS) Destroy(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args DestroyArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	if _, ok := z.Data.Datasets[args.Name]; !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+	delete(z.Data.Datasets, args.Name)
+	delete(z.Data.Data, args.Name)
+	return nil, nil, nil
+}
+
+func (z *MockZFS) Exists(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CommonArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	_, ok := z.Data.Datasets[args.Name]
+	return &ExistsResult{ok}, nil, nil
+}
+
+func (z *MockZFS) Get(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CommonArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	dataset, ok := z.Data.Datasets[args.Name]
+	if !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+	return &DatasetResult{dataset}, nil, nil
+}
+
+func (z *MockZFS) Holds(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CommonArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	if _, ok := z.Data.Datasets[args.Name]; !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+
+	return &HoldsResult{[]string{}}, nil, nil
+}
+
+func (z *MockZFS) List(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args ListArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if len(args.Types) == 0 {
+		args.Types = []string{"all"}
+	}
+	datasets := make([]*Dataset, len(z.Data.Datasets))
+	for _, dataset := range z.Data.Datasets {
+		for _, t := range args.Types {
+			if t == dataset.Properties.Type || t == "all" {
+				datasets = append(datasets, dataset)
+				break
+			}
+		}
+	}
+
+	return &ListResult{datasets}, nil, nil
+}
+
+func (z *MockZFS) Mount(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args MountArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+	if _, ok := z.Data.Datasets[args.Name]; !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+
+	return nil, nil, nil
+}
+
+func (z *MockZFS) Receive(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CommonArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+	if req.StreamURL == nil {
+		return nil, nil, errors.New("missing request stream-url")
+	}
+
+	r, w := io.Pipe()
+	go func() {
+		defer logrusx.LogReturnedErr(w.Close, nil, "failed to close writer")
+		logrusx.LogReturnedErr(func() error {
+			return acomm.Stream(w, req.StreamURL)
+		}, logrus.Fields{"streamURL": req.StreamURL}, "failed to stream")
+	}()
+
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	z.Data.Data[args.Name] = data
+	z.Data.Datasets[args.Name] = &Dataset{Name: args.Name}
+	return nil, nil, nil
+}
+
+func (z *MockZFS) Rename(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args RenameArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+	if args.Origin == "" {
+		return nil, nil, errors.New("missing arg: origin")
+	}
+
+	origin, ok := z.Data.Datasets[args.Origin]
+	if !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+	if _, ok = z.Data.Datasets[args.Name]; ok {
+		return nil, nil, errors.New("dataset already exists")
+	}
+
+	z.Data.Datasets[args.Name] = origin
+	delete(z.Data.Datasets, args.Origin)
+	if data, ok := z.Data.Data[args.Origin]; ok {
+		z.Data.Data[args.Name] = data
+		delete(z.Data.Data, args.Origin)
+	}
+	return nil, nil, nil
+}
+
+func (z *MockZFS) Rollback(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args RollbackArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+	if _, ok := z.Data.Datasets[args.Name]; !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+	return nil, nil, nil
+}
+
+func (z *MockZFS) Send(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args CommonArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+
+	data, ok := z.Data.Data[args.Name]
+	if !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+
+	reader := bytes.NewReader(data)
+
+	addr, err := z.tracker.NewStreamUnix(z.config.StreamDir("zfs-send"), ioutil.NopCloser(reader))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, addr, nil
+}
+
+func (z *MockZFS) Snapshot(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args SnapshotArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+	if args.SnapName == "" {
+		return nil, nil, errors.New("missing arg: snapname")
+	}
+
+	dataset, ok := z.Data.Datasets[args.Name]
+	if !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+
+	snapName := args.Name + "@" + args.SnapName
+	*z.Data.Datasets[snapName] = *dataset
+	z.Data.Datasets[snapName].Name = snapName
+	z.Data.Datasets[snapName].Properties.Type = "snapshot"
+
+	return nil, nil, nil
+}
+
+func (z *MockZFS) Unmount(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args UnmountArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
+	if args.Name == "" {
+		return nil, nil, errors.New("missing arg: name")
+	}
+	if _, ok := z.Data.Datasets[args.Name]; !ok {
+		return nil, nil, errors.New("dataset not found")
+	}
+
+	return nil, nil, nil
+}

--- a/providers/zfs/mock.go
+++ b/providers/zfs/mock.go
@@ -14,17 +14,20 @@ import (
 	"github.com/cerana/cerana/zfs"
 )
 
+// MockZFS is a mock ZFS provider.
 type MockZFS struct {
 	config  *provider.Config
 	tracker *acomm.Tracker
 	Data    *MockZFSData
 }
 
+// MockZFSData is the in-memory data structure for the MockZFS.
 type MockZFSData struct {
 	Datasets map[string]*Dataset
 	Data     map[string][]byte
 }
 
+// NewMockZFS creates a new instance of MockZFS.
 func NewMockZFS(config *provider.Config, tracker *acomm.Tracker) *MockZFS {
 	return &MockZFS{
 		config:  config,
@@ -36,6 +39,7 @@ func NewMockZFS(config *provider.Config, tracker *acomm.Tracker) *MockZFS {
 	}
 }
 
+// RegisterTasks registers all MockZFS tasks.
 func (z *MockZFS) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("zfs-clone", z.Clone)
 	server.RegisterTask("zfs-create", z.Create)
@@ -53,6 +57,7 @@ func (z *MockZFS) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("zfs-unmount", z.Unmount)
 }
 
+// Clone clones a mock dataset.
 func (z *MockZFS) Clone(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CloneArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -79,6 +84,7 @@ func (z *MockZFS) Clone(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &DatasetResult{z.Data.Datasets[args.Name]}, nil, nil
 }
 
+// Create creats a mock dataset.
 func (z *MockZFS) Create(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CreateArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -106,6 +112,7 @@ func (z *MockZFS) Create(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &DatasetResult{z.Data.Datasets[args.Name]}, nil, nil
 }
 
+// Destroy destroys a mock dataset.
 func (z *MockZFS) Destroy(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args DestroyArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -123,6 +130,7 @@ func (z *MockZFS) Destroy(req *acomm.Request) (interface{}, *url.URL, error) {
 	return nil, nil, nil
 }
 
+// Exists checks whether a mock dataset exists.
 func (z *MockZFS) Exists(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CommonArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -137,6 +145,7 @@ func (z *MockZFS) Exists(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &ExistsResult{ok}, nil, nil
 }
 
+// Get retrieves a mock dataset.
 func (z *MockZFS) Get(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CommonArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -154,6 +163,7 @@ func (z *MockZFS) Get(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &DatasetResult{dataset}, nil, nil
 }
 
+// Holds retrieves a mock dataset's holds.
 func (z *MockZFS) Holds(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CommonArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -171,6 +181,7 @@ func (z *MockZFS) Holds(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &HoldsResult{[]string{}}, nil, nil
 }
 
+// List returns all mock datasets.
 func (z *MockZFS) List(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args ListArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -193,6 +204,7 @@ func (z *MockZFS) List(req *acomm.Request) (interface{}, *url.URL, error) {
 	return &ListResult{datasets}, nil, nil
 }
 
+// Mount mounts a mock dataset.
 func (z *MockZFS) Mount(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args MountArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -209,6 +221,7 @@ func (z *MockZFS) Mount(req *acomm.Request) (interface{}, *url.URL, error) {
 	return nil, nil, nil
 }
 
+// Receive receives mock dataset data and creates a mock dataset.
 func (z *MockZFS) Receive(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CommonArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -239,6 +252,7 @@ func (z *MockZFS) Receive(req *acomm.Request) (interface{}, *url.URL, error) {
 	return nil, nil, nil
 }
 
+// Rename renames a mock dataset.
 func (z *MockZFS) Rename(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args RenameArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -269,6 +283,7 @@ func (z *MockZFS) Rename(req *acomm.Request) (interface{}, *url.URL, error) {
 	return nil, nil, nil
 }
 
+// Rollback rolls back to a mock dataset.
 func (z *MockZFS) Rollback(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args RollbackArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -284,6 +299,7 @@ func (z *MockZFS) Rollback(req *acomm.Request) (interface{}, *url.URL, error) {
 	return nil, nil, nil
 }
 
+// Send sends mock dataset data.
 func (z *MockZFS) Send(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args CommonArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -309,6 +325,7 @@ func (z *MockZFS) Send(req *acomm.Request) (interface{}, *url.URL, error) {
 	return nil, addr, nil
 }
 
+// Snapshot snapshots a mock dataset.
 func (z *MockZFS) Snapshot(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args SnapshotArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
@@ -335,6 +352,7 @@ func (z *MockZFS) Snapshot(req *acomm.Request) (interface{}, *url.URL, error) {
 	return nil, nil, nil
 }
 
+// Unmount unmounts a mock dataset.
 func (z *MockZFS) Unmount(req *acomm.Request) (interface{}, *url.URL, error) {
 	var args UnmountArgs
 	if err := req.UnmarshalArgs(&args); err != nil {

--- a/providers/zfs/mock.go
+++ b/providers/zfs/mock.go
@@ -191,7 +191,7 @@ func (z *MockZFS) List(req *acomm.Request) (interface{}, *url.URL, error) {
 	if len(args.Types) == 0 {
 		args.Types = []string{"all"}
 	}
-	datasets := make([]*Dataset, len(z.Data.Datasets))
+	datasets := make([]*Dataset, 0, len(z.Data.Datasets))
 	for _, dataset := range z.Data.Datasets {
 		for _, t := range args.Types {
 			if t == dataset.Properties.Type || t == "all" {


### PR DESCRIPTION
## Issues affected/resolved

(See https://github.com/blog/1506-closing-issues-via-pull-requests)
Resolves #159
## Description:

Pulls local information on datasets, bundles, and the node. Updates the appropriate heartbeats with the clusterconf provider.

Also includes mock providers for metrics, zfs, systemd, clusterconf.
## Note:

Depends on #145

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/179)

<!-- Reviewable:end -->
