### PR TITLE
Lazy opening of the zfs file descriptor

### DIFF
--- a/zfs/clone.go
+++ b/zfs/clone.go
@@ -22,5 +22,5 @@ func clone(name, origin string, props map[string]interface{}) error {
 		return err
 	}
 
-	return ioctl(zfs, name, encoded.Bytes(), nil)
+	return ioctl(zfs(), name, encoded.Bytes(), nil)
 }

--- a/zfs/common.go
+++ b/zfs/common.go
@@ -1,13 +1,24 @@
 package zfs
 
-import "os"
+import (
+	"os"
+	"sync"
+)
 
-var zfs *os.File
+// zfsFD is the zfs device file descriptor. Do not use this directly. Access by
+// calling zfs() instead. The initialization is protected by once.
+var zfsFD *os.File
+var once sync.Once
 
-func init() {
+func openZFS() {
 	z, err := os.OpenFile("/dev/zfs", os.O_RDWR, 0)
 	if err != nil {
 		panic(err)
 	}
-	zfs = z
+	zfsFD = z
+}
+
+func zfs() *os.File {
+	once.Do(openZFS)
+	return zfsFD
 }

--- a/zfs/create.go
+++ b/zfs/create.go
@@ -22,5 +22,5 @@ func create(name string, createType dmuType, props map[string]interface{}) error
 		return err
 	}
 
-	return ioctl(zfs, name, encoded.Bytes(), nil)
+	return ioctl(zfs(), name, encoded.Bytes(), nil)
 }

--- a/zfs/destroy.go
+++ b/zfs/destroy.go
@@ -19,5 +19,5 @@ func destroy(name string, deferFlag bool) error {
 		return err
 	}
 
-	return ioctl(zfs, name, encoded.Bytes(), nil)
+	return ioctl(zfs(), name, encoded.Bytes(), nil)
 }

--- a/zfs/exists.go
+++ b/zfs/exists.go
@@ -19,7 +19,7 @@ func exists(name string) error {
 		return err
 	}
 
-	return ioctl(zfs, name, encoded.Bytes(), nil)
+	return ioctl(zfs(), name, encoded.Bytes(), nil)
 }
 
 // Exists determines whether a dataset exists or not.

--- a/zfs/holds.go
+++ b/zfs/holds.go
@@ -23,7 +23,7 @@ func holds(name string) ([]string, error) {
 	out := make([]byte, 1024)
 	copy(out, emptyList)
 
-	err = ioctl(zfs, name, encoded.Bytes(), out)
+	err = ioctl(zfs(), name, encoded.Bytes(), out)
 	if err != nil {
 		return nil, err
 	}

--- a/zfs/list.go
+++ b/zfs/list.go
@@ -107,7 +107,7 @@ func list(name string, types map[string]bool, recurse bool, depth uint64) (ret [
 		return
 	}
 
-	err = ioctl(zfs, name, encoded.Bytes(), nil)
+	err = ioctl(zfs(), name, encoded.Bytes(), nil)
 	if err != nil {
 		return
 	}

--- a/zfs/rename.go
+++ b/zfs/rename.go
@@ -23,7 +23,7 @@ func rename(name, newName string, recursive bool) (string, error) {
 	}
 
 	out := make([]byte, 1024)
-	err = ioctl(zfs, name, encoded.Bytes(), out)
+	err = ioctl(zfs(), name, encoded.Bytes(), out)
 
 	var failedName string
 	if err != nil && recursive {

--- a/zfs/rollback.go
+++ b/zfs/rollback.go
@@ -19,7 +19,7 @@ func rollback(name string) (string, error) {
 	}
 
 	out := make([]byte, 1024)
-	err = ioctl(zfs, name, encoded.Bytes(), out)
+	err = ioctl(zfs(), name, encoded.Bytes(), out)
 
 	var snapName string
 	if err == nil {

--- a/zfs/send.go
+++ b/zfs/send.go
@@ -35,5 +35,5 @@ func send(name string, outputFD uintptr, fromSnap string, largeBlockOK, embedOK 
 		return err
 	}
 
-	return ioctl(zfs, name, encoded.Bytes(), nil)
+	return ioctl(zfs(), name, encoded.Bytes(), nil)
 }

--- a/zfs/snapshot.go
+++ b/zfs/snapshot.go
@@ -30,7 +30,7 @@ func snapshot(pool string, snapNames []string, props map[string]string) (map[str
 	}
 
 	out := make([]byte, 1024)
-	err = ioctl(zfs, pool, encoded.Bytes(), out)
+	err = ioctl(zfs(), pool, encoded.Bytes(), out)
 
 	var errlist map[string]syscall.Errno
 	if errno, ok := err.(syscall.Errno); ok && errno == syscall.EEXIST {


### PR DESCRIPTION
## Issues affected/resolved

(See https://github.com/blog/1506-closing-issues-via-pull-requests)
Resolves #173
## Description:

Rather than open it in an init(), lazy open when its first needed. This keeps the private function calls clean and simple will allowing other packages to import the `zfs` package for data structures without needing permissions to read/write to zfs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/185)

<!-- Reviewable:end -->
