### PR TITLE
errorutils.First

### DIFF
--- a/pkg/errorutils/README.md
+++ b/pkg/errorutils/README.md
@@ -1,0 +1,17 @@
+# errorutils
+
+[![errorutils](https://godoc.org/github.com/cerana/cerana/pkg/errorutils?status.svg)](https://godoc.org/github.com/cerana/cerana/pkg/errorutils)
+
+Package errorutils provides helper functions for dealing with errors.
+
+## Usage
+
+#### func  First
+
+```go
+func First(errors ...error) error
+```
+First returns the first non-nil error in a set of errors.
+
+--
+*Generated with [godocdown](https://github.com/robertkrimen/godocdown)*

--- a/pkg/errorutils/errorutils.go
+++ b/pkg/errorutils/errorutils.go
@@ -1,0 +1,12 @@
+// Package errorutils provides helper functions for dealing with errors.
+package errorutils
+
+// First returns the first non-nil error in a set of errors.
+func First(errors ...error) error {
+	for _, err := range errors {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/errorutils/errorutils_test.go
+++ b/pkg/errorutils/errorutils_test.go
@@ -1,0 +1,37 @@
+package errorutils_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cerana/cerana/pkg/errorutils"
+	"github.com/stretchr/testify/suite"
+)
+
+type errorUtils struct {
+	suite.Suite
+}
+
+func TestErrorUtils(t *testing.T) {
+	suite.Run(t, new(errorUtils))
+}
+
+func (s *errorUtils) TestFirst() {
+	tests := []struct {
+		in  []error
+		out error
+	}{
+		{[]error{errors.New("foo")}, errors.New("foo")},
+		{[]error{errors.New("foo"), errors.New("bar"), errors.New("baz")}, errors.New("foo")},
+		{[]error{nil, errors.New("bar"), errors.New("baz")}, errors.New("bar")},
+		{[]error{nil, nil, errors.New("baz")}, errors.New("baz")},
+		{[]error{nil, errors.New("bar"), nil}, errors.New("bar")},
+		{[]error{errors.New("foo"), nil, errors.New("baz")}, errors.New("foo")},
+		{[]error{}, nil},
+	}
+
+	for _, test := range tests {
+		s.Equal(test.out, errorutils.First(test.in...), fmt.Sprintf("%+v", test.in))
+	}
+}

--- a/zfs/dataset.go
+++ b/zfs/dataset.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/cerana/cerana/pkg/errorutils"
 	"github.com/cerana/cerana/zfs/nv"
 	gzfs "github.com/mistifyio/go-zfs"
 )
@@ -482,13 +483,7 @@ func (pfc *pipeFdCloser) Fd() uintptr {
 }
 
 func (pfc *pipeFdCloser) Close() error {
-	var err error
-	for _, theErr := range []error{<-pfc.done, pfc.r.Close(), pfc.w.Close()} {
-		if err == nil {
-			err = theErr
-		}
-	}
-	return err
+	return errorutils.First(<-pfc.done, pfc.r.Close(), pfc.w.Close())
 }
 
 func (pfc *pipeFdCloser) Copy(output io.Writer) {

--- a/zfs/list.go
+++ b/zfs/list.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/cerana/cerana/pkg/errorutils"
 	"github.com/cerana/cerana/zfs/nv"
 )
 
@@ -74,11 +75,7 @@ func list(name string, types map[string]bool, recurse bool, depth uint64) (ret [
 		return
 	}
 	defer func() {
-		for _, theErr := range []error{writer.Close(), pipeReader.Close()} {
-			if err == nil {
-				err = theErr
-			}
-		}
+		err = errorutils.First(err, writer.Close(), pipeReader.Close())
 	}()
 
 	opts := map[string]interface{}{


### PR DESCRIPTION
## Issues affected/resolved

(See https://github.com/blog/1506-closing-issues-via-pull-requests)
Resolves #119
## Description:

Added error handling helper package `errorutils` with a function `First` to return the first non-nil error. Updated the two places in `zfs` that were the reason for this ticket.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/186)

<!-- Reviewable:end -->
