### PR TITLE
rename logrusx.MistifyFormatter -> JSONFormatter

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	log.SetFormatter(&logx.MistifyFormatter{})
+	log.SetFormatter(&logx.JSONFormatter{})
 
 	config := coordinator.NewConfig(nil, nil)
 	flag.Parse()

--- a/cmd/metrics-provider/main.go
+++ b/cmd/metrics-provider/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	log.SetFormatter(&logx.MistifyFormatter{})
+	log.SetFormatter(&logx.JSONFormatter{})
 
 	config := provider.NewConfig(nil, nil)
 	flag.Parse()

--- a/cmd/systemd-provider/main.go
+++ b/cmd/systemd-provider/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	log.SetFormatter(&logx.MistifyFormatter{})
+	log.SetFormatter(&logx.JSONFormatter{})
 
 	config := systemd.NewConfig(nil, nil)
 	flag.StringP("unit-file-dir", "d", "", "directory in which to create unit files")

--- a/cmd/zfs-provider/main.go
+++ b/cmd/zfs-provider/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	log.SetFormatter(&logx.MistifyFormatter{})
+	log.SetFormatter(&logx.JSONFormatter{})
 
 	config := provider.NewConfig(nil, nil)
 	flag.Parse()

--- a/pkg/logrusx/README.md
+++ b/pkg/logrusx/README.md
@@ -44,20 +44,21 @@ type FieldError struct {
 FieldError contains both the error struct and error message as explicit
 properties, including both when JSON marshaling.
 
-#### type MistifyFormatter
+#### type JSONFormatter
 
 ```go
-type MistifyFormatter struct {
+type JSONFormatter struct {
 	log.JSONFormatter
 }
 ```
 
-MistifyFormatter is a custom logrus formatter extending JSONFormatter
+JSONFormatter is a custom formatter extending logrus.JSONFormatter with better
+handling of error values
 
-#### func (*MistifyFormatter) Format
+#### func (*JSONFormatter) Format
 
 ```go
-func (f *MistifyFormatter) Format(entry *log.Entry) ([]byte, error)
+func (f *JSONFormatter) Format(entry *log.Entry) ([]byte, error)
 ```
 Format replaces any error field values with a FieldError and produces a JSON
 formatted log entry

--- a/pkg/logrusx/ext.go
+++ b/pkg/logrusx/ext.go
@@ -10,7 +10,7 @@ func DefaultSetup(logLevel string) error {
 	if err != nil {
 		return err
 	}
-	log.SetFormatter(&MistifyFormatter{})
+	log.SetFormatter(&JSONFormatter{})
 	return nil
 }
 

--- a/pkg/logrusx/ext_test.go
+++ b/pkg/logrusx/ext_test.go
@@ -66,7 +66,7 @@ func (s *ExtTestSuite) TestDefaultSetup() {
 	std := log.StandardLogger()
 	s.NoError(logx.DefaultSetup("debug"))
 	s.Equal(log.DebugLevel, log.GetLevel())
-	s.IsType(&logx.MistifyFormatter{}, std.Formatter)
+	s.IsType(&logx.JSONFormatter{}, std.Formatter)
 }
 
 func (s *ExtTestSuite) TestLogReturnedErr() {

--- a/pkg/logrusx/formatter.go
+++ b/pkg/logrusx/formatter.go
@@ -11,13 +11,12 @@ import (
 )
 
 type (
-	// MistifyFormatter is a custom logrus formatter extending JSONFormatter
-	MistifyFormatter struct {
+	// JSONFormatter is a custom formatter extending logrus.JSONFormatter with better handling of error values
+	JSONFormatter struct {
 		log.JSONFormatter
 	}
 
-	// FieldError contains both the error struct and error message as explicit
-	// properties, including both when JSON marshaling.
+	// FieldError contains both the error struct and error message as explicit properties, including both when JSON marshaling.
 	FieldError struct {
 		Error   error
 		Message string
@@ -25,9 +24,8 @@ type (
 	}
 )
 
-// Format replaces any error field values with a FieldError and produces a JSON
-// formatted log entry
-func (f *MistifyFormatter) Format(entry *log.Entry) ([]byte, error) {
+// Format replaces any error field values with a FieldError and produces a JSON formatted log entry
+func (f *JSONFormatter) Format(entry *log.Entry) ([]byte, error) {
 	for k, v := range entry.Data {
 		if err, ok := v.(error); ok {
 			// Get the call stack and remove this function call from it
@@ -43,9 +41,10 @@ func (f *MistifyFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return f.JSONFormatter.Format(entry)
 }
 
-func (f *MistifyFormatter) callStack() []string {
+func (f *JSONFormatter) callStack() []string {
 	stack := make([]string, 0, 4)
 	for i := 1; ; i++ {
+		// TODO: use runtime.Callers && runtime.CallersFrames when go1.7 is out
 		pc, file, line, ok := runtime.Caller(i)
 		if !ok {
 			break

--- a/pkg/logrusx/formatter_test.go
+++ b/pkg/logrusx/formatter_test.go
@@ -24,7 +24,7 @@ func (s *FormatterTestSuite) SetupTest() {
 	// Setup a new Logger instance
 	s.Log = log.New()
 	s.Log.Out = s.Buffer
-	s.Log.Formatter = &logx.MistifyFormatter{}
+	s.Log.Formatter = &logx.JSONFormatter{}
 }
 
 func TestFormatterTestSuite(t *testing.T) {
@@ -43,7 +43,7 @@ func (s *FormatterTestSuite) TestMistifyFormatterFormat() {
 		Message: "test error message",
 	}
 
-	mf := &logx.MistifyFormatter{}
+	mf := &logx.JSONFormatter{}
 	jsonBytes, err := mf.Format(entry)
 	s.NoError(err)
 	var loggedEntry map[string]interface{}

--- a/provider/examples/simple/cmd/provider-simple/main.go
+++ b/provider/examples/simple/cmd/provider-simple/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	log.SetFormatter(&logx.MistifyFormatter{})
+	log.SetFormatter(&logx.JSONFormatter{})
 
 	config := provider.NewConfig(nil, nil)
 


### PR DESCRIPTION
#### Description:

Change `logrusx.MistifyFormatter` to `logrusx.JSONFormatter`. I was originally going to rename to `CeranaFormatter` but it seems silly.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #personal-issue

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/196)

<!-- Reviewable:end -->
