### PR TITLE
Fix systemd unit_file_dir flag name for consistency

### DIFF
--- a/cmd/systemd-provider/main.go
+++ b/cmd/systemd-provider/main.go
@@ -14,7 +14,7 @@ func main() {
 	log.SetFormatter(&logx.JSONFormatter{})
 
 	config := systemd.NewConfig(nil, nil)
-	flag.StringP("unit-file-dir", "d", "", "directory in which to create unit files")
+	flag.StringP("unit_file_dir", "d", "", "directory in which to create unit files")
 	flag.Parse()
 
 	dieOnError(config.LoadConfig())


### PR DESCRIPTION
#### Description:

Everywhere else in the code was looking for `unit_file_dir`, but the flag was added as `unit-file-dir`. Make it consistent.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/213)

<!-- Reviewable:end -->
