### PR TITLE
Clusterconf bundle overlay 

### DIFF
--- a/cmd/statspusher/bundle_test.go
+++ b/cmd/statspusher/bundle_test.go
@@ -55,7 +55,7 @@ func (s *StatsPusher) TestGetBundles() {
 		}
 		s.clusterConf.Data.Bundles = make(map[uint64]*clusterconf.Bundle)
 		for _, id := range test.known {
-			s.clusterConf.Data.Bundles[id] = &clusterconf.Bundle{BundleConf: &clusterconf.BundleConf{ID: id}}
+			s.clusterConf.Data.Bundles[id] = &clusterconf.Bundle{BundleConf: clusterconf.BundleConf{ID: id}}
 		}
 		bundles, err := s.statsPusher.getBundles()
 		if !s.NoError(err, test.desc) {
@@ -74,7 +74,7 @@ func (s *StatsPusher) TestGetBundles() {
 func (s *StatsPusher) TestRunHealthChecks() {
 	// TODO: Write proper tests when this is done
 	bundles := []*clusterconf.Bundle{
-		{BundleConf: &clusterconf.BundleConf{ID: 123}},
+		{BundleConf: clusterconf.BundleConf{ID: 123}},
 	}
 
 	healthy, err := s.statsPusher.runHealthChecks(bundles)
@@ -87,7 +87,7 @@ func (s *StatsPusher) TestSendBundleHeartbeats() {
 	ip := net.ParseIP("123.123.123.123")
 	bundles := []uint64{123, 456}
 	for _, id := range bundles {
-		s.clusterConf.Data.Bundles[id] = &clusterconf.Bundle{BundleConf: &clusterconf.BundleConf{ID: id}}
+		s.clusterConf.Data.Bundles[id] = &clusterconf.Bundle{BundleConf: clusterconf.BundleConf{ID: id}}
 	}
 	s.NoError(s.statsPusher.sendBundleHeartbeats(bundles, serial, ip))
 	for _, id := range bundles {

--- a/cmd/statspusher/dataset_test.go
+++ b/cmd/statspusher/dataset_test.go
@@ -32,7 +32,7 @@ func (s *StatsPusher) TestGetDatasets() {
 		}
 		s.clusterConf.Data.Datasets = make(map[string]*clusterconf.Dataset)
 		for _, id := range test.known {
-			s.clusterConf.Data.Datasets[id] = &clusterconf.Dataset{DatasetConf: &clusterconf.DatasetConf{ID: id}}
+			s.clusterConf.Data.Datasets[id] = &clusterconf.Dataset{DatasetConf: clusterconf.DatasetConf{ID: id}}
 		}
 		datasets, err := s.statsPusher.getDatasets()
 		if !s.NoError(err, test.desc) {
@@ -57,7 +57,7 @@ func (s *StatsPusher) TestSendDatasetHeartbeats() {
 	s.zfs.Data.Datasets = make(map[string]*zfsp.Dataset)
 	s.zfs.Data.Datasets[name] = &zfsp.Dataset{Name: name, Properties: &zfs.DatasetProperties{Type: "volume"}}
 	s.clusterConf.Data.Datasets = make(map[string]*clusterconf.Dataset)
-	s.clusterConf.Data.Datasets[name] = &clusterconf.Dataset{DatasetConf: &clusterconf.DatasetConf{ID: name}}
+	s.clusterConf.Data.Datasets[name] = &clusterconf.Dataset{DatasetConf: clusterconf.DatasetConf{ID: name}}
 	ip := net.ParseIP(s.metrics.Data.Network.Interfaces[0].Addrs[0].Addr)
 	s.NoError(s.statsPusher.sendDatasetHeartbeats([]string{name}, ip))
 	s.True(s.clusterConf.Data.Datasets[name].Nodes[ip.String()])

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -10,9 +10,10 @@
 const (
 	RWZFS = iota
 	TempZFS
-	RamDisk
+	RAMDisk
 )
 ```
+Valid bundle dataset types
 
 #### type Bundle
 
@@ -63,6 +64,7 @@ BundleDataset is configuration for a dataset associated with a bundle.
 type BundleDatasetType int
 ```
 
+BundleDatasetType is the type of dataset to be used in a bundle.
 
 #### type BundleHeartbeatArgs
 

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -419,7 +419,7 @@ to be sent.
 
 ```go
 type Defaults struct {
-	*DefaultsConf
+	DefaultsConf
 
 	ModIndex uint64 `json:"modIndex"`
 }

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -10,7 +10,7 @@
 
 ```go
 type Bundle struct {
-	*BundleConf
+	BundleConf
 
 	// Nodes contains the set of nodes on which the dataset is currently in use.
 	// The map keys are serials.
@@ -133,7 +133,7 @@ ints.
 
 ```go
 type BundleService struct {
-	*ServiceConf
+	ServiceConf
 	Datasets map[string]*ServiceDataset `json:"datasets"`
 }
 ```

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -6,6 +6,14 @@
 
 ## Usage
 
+```go
+const (
+	RWZFS = iota
+	TempZFS
+	RamDisk
+)
+```
+
 #### type Bundle
 
 ```go
@@ -40,14 +48,21 @@ BundleConf is the configuration of a bundle.
 
 ```go
 type BundleDataset struct {
-	Name  string `json:"name"`
-	ID    string `json:"id"`
-	Type  int    `json:"type"` // TODO: Decide on type for this. Iota?
-	Quota int    `json:"type"`
+	Name  string            `json:"name"`
+	ID    string            `json:"id"`
+	Type  BundleDatasetType `json:"type"`
+	Quota int               `json:"type"`
 }
 ```
 
 BundleDataset is configuration for a dataset associated with a bundle.
+
+#### type BundleDatasetType
+
+```go
+type BundleDatasetType int
+```
+
 
 #### type BundleHeartbeatArgs
 
@@ -60,16 +75,6 @@ type BundleHeartbeatArgs struct {
 ```
 
 BundleHeartbeatArgs are arguments for updating a dataset node heartbeat.
-
-#### type BundleIDArgs
-
-```go
-type BundleIDArgs struct {
-	ID uint64 `json:"id"`
-}
-```
-
-BundleIDArgs are args for bundle tasks that only require bundle id.
 
 #### type BundleListResult
 
@@ -134,7 +139,7 @@ ints.
 ```go
 type BundleService struct {
 	ServiceConf
-	Datasets map[string]*ServiceDataset `json:"datasets"`
+	Datasets map[string]ServiceDataset `json:"datasets"`
 }
 ```
 
@@ -448,6 +453,27 @@ type DefaultsPayload struct {
 DefaultsPayload can be used for task args or result when a cluster object needs
 to be sent.
 
+#### type DeleteBundleArgs
+
+```go
+type DeleteBundleArgs struct {
+	ID uint64 `json:"id"`
+}
+```
+
+DeleteBundleArgs are args for bundle delete task.
+
+#### type GetBundleArgs
+
+```go
+type GetBundleArgs struct {
+	ID              uint64 `json:"id"`
+	CombinedOverlay bool   `json:"overlay"`
+}
+```
+
+GetBundleArgs are args for retrieving a bundle.
+
 #### type HealthCheck
 
 ```go
@@ -469,6 +495,16 @@ type IDArgs struct {
 ```
 
 IDArgs are arguments for operations requiring only an ID.
+
+#### type ListBundleArgs
+
+```go
+type ListBundleArgs struct {
+	CombinedOverlay bool `json:"overlay"`
+}
+```
+
+ListBundleArgs are args for retrieving a bundle list.
 
 #### type MockClusterConf
 
@@ -730,11 +766,11 @@ Service is information about a service.
 
 ```go
 type ServiceConf struct {
-	ID           string                  `json:"id"`
-	Dataset      string                  `json:"dataset"`
-	HealthChecks map[string]*HealthCheck `json:"healthChecks"`
-	Limits       *ResourceLimits         `json:"limits"`
-	Env          map[string]string       `json:"env"`
+	ID           string                 `json:"id"`
+	Dataset      string                 `json:"dataset"`
+	HealthChecks map[string]HealthCheck `json:"healthChecks"`
+	Limits       ResourceLimits         `json:"limits"`
+	Env          map[string]string      `json:"env"`
 }
 ```
 

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -34,11 +34,11 @@ Bundle is information about a bundle of services.
 
 ```go
 type BundleConf struct {
-	ID         uint64                    `json:"id"`
-	Datasets   map[string]*BundleDataset `json:"datasets"`
-	Services   map[string]*BundleService `json:"services"`
-	Redundancy int                       `json:"redundancy"`
-	Ports      BundlePorts               `json:"ports"`
+	ID         uint64                   `json:"id"`
+	Datasets   map[string]BundleDataset `json:"datasets"`
+	Services   map[string]BundleService `json:"services"`
+	Redundancy int                      `json:"redundancy"`
+	Ports      BundlePorts              `json:"ports"`
 }
 ```
 
@@ -113,7 +113,7 @@ BundlePort is configuration for a port associated with a bundle.
 #### type BundlePorts
 
 ```go
-type BundlePorts map[int]*BundlePort
+type BundlePorts map[int]BundlePort
 ```
 
 BundlePorts is a map of port numbers to port information.

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -355,7 +355,7 @@ ConfigData defines the structure of the config data (e.g. in the config file)
 
 ```go
 type Dataset struct {
-	*DatasetConf
+	DatasetConf
 
 	// Nodes contains the set of nodes on which the dataset is currently in use.
 	// The map keys are IP address strings.

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -717,7 +717,7 @@ ResourceLimits is configuration for resource upper bounds.
 
 ```go
 type Service struct {
-	*ServiceConf
+	ServiceConf
 
 	// ModIndex should be treated as opaque, but passed back on updates
 	ModIndex uint64 `json:"modIndex"`

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -452,9 +452,9 @@ to be sent.
 
 ```go
 type HealthCheck struct {
-	ID               string   `json:"id"`
-	ProtocolProvider string   `json:"protocolProvider"`
-	Parameters       []string `json:"parameters"`
+	ID   string      `json:"id"`
+	Type string      `json:"type"`
+	Args interface{} `json:"args"`
 }
 ```
 
@@ -732,7 +732,7 @@ Service is information about a service.
 type ServiceConf struct {
 	ID           string                  `json:"id"`
 	Dataset      string                  `json:"dataset"`
-	HealthChecks map[string]*HealthCheck `json:"healthCheck"`
+	HealthChecks map[string]*HealthCheck `json:"healthChecks"`
 	Limits       *ResourceLimits         `json:"limits"`
 	Env          map[string]string       `json:"env"`
 }

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -3,6 +3,7 @@ package clusterconf
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net"
 	"net/url"
@@ -17,6 +18,14 @@ import (
 )
 
 const bundlesPrefix string = "bundles"
+
+type BundleDatasetType int
+
+const (
+	RWZFS = iota
+	TempZFS
+	RamDisk
+)
 
 // Bundle is information about a bundle of services.
 type Bundle struct {
@@ -72,17 +81,89 @@ func (p BundlePorts) UnmarshalJSON(data []byte) error {
 
 // BundleDataset is configuration for a dataset associated with a bundle.
 type BundleDataset struct {
-	Name  string `json:"name"`
-	ID    string `json:"id"`
-	Type  int    `json:"type"` // TODO: Decide on type for this. Iota?
-	Quota int    `json:"type"`
+	Name  string            `json:"name"`
+	ID    string            `json:"id"`
+	Type  BundleDatasetType `json:"type"`
+	Quota int               `json:"type"`
+}
+
+func (d *BundleDataset) overlayOn(base *Dataset) (*BundleDataset, error) {
+	if d.ID != base.ID {
+		return nil, errors.New("dataset ids do not match")
+	}
+
+	// duplicate the BundleDataset
+	result := &BundleDataset{}
+	*result = *d
+
+	// overlay data
+	if result.Quota <= 0 {
+		result.Quota = base.Quota
+	}
+
+	return result, nil
 }
 
 // BundleService is configuration overrides for a service of a bundle and
 // associated bundles.
 type BundleService struct {
 	ServiceConf
-	Datasets map[string]*ServiceDataset `json:"datasets"`
+	Datasets map[string]ServiceDataset `json:"datasets"`
+}
+
+func (s *BundleService) overlayOn(base *Service) (*BundleService, error) {
+	if s.ID != base.ID {
+		return nil, errors.New("service ids do not match")
+	}
+
+	// duplicate the BundleService
+	// maps are pointers, so need to be duplicated separately.
+	result := &BundleService{
+		ServiceConf: s.ServiceConf,
+		Datasets:    make(map[string]ServiceDataset),
+	}
+	for k, v := range s.Datasets {
+		result.Datasets[k] = v
+	}
+	result.HealthChecks = make(map[string]HealthCheck)
+	for k, v := range s.HealthChecks {
+		result.HealthChecks[k] = v
+	}
+	result.Env = make(map[string]string)
+	for k, v := range s.Env {
+		result.Env[k] = v
+	}
+
+	// overlay data
+	if result.Dataset == "" {
+		result.Dataset = base.Dataset
+	}
+
+	if result.Limits.CPU <= 0 {
+		result.Limits.CPU = base.Limits.CPU
+	}
+	if result.Limits.Memory <= 0 {
+		result.Limits.Memory = base.Limits.Memory
+	}
+	if result.Limits.Processes <= 0 {
+		result.Limits.Processes = base.Limits.Processes
+	}
+
+	for id, hc := range base.HealthChecks {
+		_, ok := result.HealthChecks[id]
+		if !ok {
+			result.HealthChecks[id] = hc
+			continue
+		}
+	}
+	for key, val := range base.Env {
+		_, ok := result.Env[key]
+		if !ok {
+			result.Env[key] = val
+		}
+	}
+
+	return result, nil
 }
 
 // ServiceDataset is configuration for mounting a dataset for a bundle service.
@@ -100,9 +181,20 @@ type BundlePort struct {
 	ExternalPort     int      `json:"externalPort"`
 }
 
-// BundleIDArgs are args for bundle tasks that only require bundle id.
-type BundleIDArgs struct {
+// DeleteBundleArgs are args for bundle delete task.
+type DeleteBundleArgs struct {
 	ID uint64 `json:"id"`
+}
+
+// GetBundleArgs are args for retrieving a bundle.
+type GetBundleArgs struct {
+	ID              uint64 `json:"id"`
+	CombinedOverlay bool   `json:"overlay"`
+}
+
+// ListBundleArgs are args for retrieving a bundle list.
+type ListBundleArgs struct {
+	CombinedOverlay bool `json:"overlay"`
 }
 
 // BundlePayload can be used for task args or result when a bundle object needs
@@ -125,7 +217,7 @@ type BundleHeartbeatArgs struct {
 
 // GetBundle retrieves a bundle.
 func (c *ClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, error) {
-	var args BundleIDArgs
+	var args GetBundleArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
 		return nil, nil, err
 	}
@@ -137,11 +229,22 @@ func (c *ClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, erro
 	if err != nil {
 		return nil, nil, err
 	}
+	if args.CombinedOverlay {
+		bundle, err = bundle.combinedOverlay()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 	return &BundlePayload{bundle}, nil, nil
 }
 
 // ListBundles retrieves a list of all bundles.
 func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, error) {
+	var args ListBundleArgs
+	if err := req.UnmarshalArgs(&args); err != nil {
+		return nil, nil, err
+	}
+
 	keys, err := c.kvKeys(bundlesPrefix)
 	if err != nil {
 		return nil, nil, err
@@ -160,20 +263,27 @@ func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, er
 	}
 
 	var wg sync.WaitGroup
-	dsChan := make(chan *Bundle, len(ids))
-	defer close(dsChan)
+	bundleChan := make(chan *Bundle, len(ids))
+	defer close(bundleChan)
 	errChan := make(chan error, len(ids))
 	defer close(errChan)
 	for id := range ids {
 		wg.Add(1)
 		go func(id uint64) {
 			defer wg.Done()
-			ds, err := c.getBundle(id)
+			bundle, err := c.getBundle(id)
 			if err != nil {
 				errChan <- err
 				return
 			}
-			dsChan <- ds
+			if args.CombinedOverlay {
+				bundle, err = bundle.combinedOverlay()
+				if err != nil {
+					errChan <- err
+					return
+				}
+			}
+			bundleChan <- bundle
 		}(id)
 	}
 	wg.Wait()
@@ -182,9 +292,9 @@ func (c *ClusterConf) ListBundles(req *acomm.Request) (interface{}, *url.URL, er
 		err := <-errChan
 		return nil, nil, err
 	}
-	bundles := make([]*Bundle, 0, len(dsChan))
-	for ds := range dsChan {
-		bundles = append(bundles, ds)
+	bundles := make([]*Bundle, 0, len(bundleChan))
+	for bundle := range bundleChan {
+		bundles = append(bundles, bundle)
 	}
 
 	return &BundleListResult{
@@ -216,7 +326,7 @@ func (c *ClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.URL, e
 
 // DeleteBundle deletes a bundle config.
 func (c *ClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.URL, error) {
-	var args BundleIDArgs
+	var args DeleteBundleArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
 		return nil, nil, err
 	}
@@ -326,6 +436,89 @@ func (b *Bundle) update() error {
 
 	// reload instead of just setting the new modIndex in case any nodes have also changed.
 	return b.reload()
+}
+
+// combinedOverlay will create a new *Bundle object containing the base configurations of datasets and services with the bundle values overlayed on top.
+// This should not be saved.
+func (b *Bundle) combinedOverlay() (*Bundle, error) {
+	var wg sync.WaitGroup
+	errorChan := make(chan error, len(b.Datasets)+len(b.Services))
+	defer close(errorChan)
+
+	// duplicate bundle
+	result := &Bundle{
+		BundleConf: b.BundleConf,
+		Nodes:      make(map[string]net.IP),
+	}
+	for k, v := range b.Nodes {
+		result.Nodes[k] = v
+	}
+	result.Datasets = make(map[string]*BundleDataset)
+	for k, v := range b.Datasets {
+		result.Datasets[k] = v
+	}
+	result.Services = make(map[string]*BundleService)
+	for k, v := range b.Services {
+		result.Services[k] = v
+	}
+	result.Ports = make(BundlePorts)
+	for k, v := range b.Ports {
+		result.Ports[k] = v
+	}
+
+	for i, d := range b.Datasets {
+		wg.Add(1)
+		go func(id string, bd *BundleDataset) {
+			defer wg.Done()
+			dataset, err := b.c.getDataset(id)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			combined, err := bd.overlayOn(dataset)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			result.Datasets[id] = combined
+		}(i, d)
+	}
+
+	for i, s := range b.Services {
+		wg.Add(1)
+		go func(id string, bs *BundleService) {
+			defer wg.Done()
+			service, err := b.c.getService(id)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			combined, err := bs.overlayOn(service)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			result.Services[id] = combined
+		}(i, s)
+	}
+
+	wg.Wait()
+
+	if len(errorChan) == 0 {
+		return result, nil
+	}
+
+	errors := make([]error, len(errorChan))
+Loop:
+	for {
+		select {
+		case err := <-errorChan:
+			errors = append(errors, err)
+		default:
+			break Loop
+		}
+	}
+	return nil, fmt.Errorf("bundle overlay failed: %+v", errors)
 }
 
 func (b *Bundle) nodeHeartbeat(serial string, ip net.IP) error {

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -434,7 +434,7 @@ func (b *Bundle) update() error {
 }
 
 // combinedOverlay will create a new *Bundle object containing the base configurations of datasets and services with the bundle values overlayed on top.
-// This should not be saved.
+// Note: Attempting to save a combined overlay bundle will result in an error.
 func (b *Bundle) combinedOverlay() (*Bundle, error) {
 	var wg sync.WaitGroup
 	errorChan := make(chan error, len(b.Datasets)+len(b.Services))

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -19,12 +19,14 @@ import (
 
 const bundlesPrefix string = "bundles"
 
+// BundleDatasetType is the type of dataset to be used in a bundle.
 type BundleDatasetType int
 
+// Valid bundle dataset types
 const (
 	RWZFS = iota
 	TempZFS
-	RamDisk
+	RAMDisk
 )
 
 // Bundle is information about a bundle of services.

--- a/providers/clusterconf/bundle.go
+++ b/providers/clusterconf/bundle.go
@@ -20,7 +20,7 @@ const bundlesPrefix string = "bundles"
 
 // Bundle is information about a bundle of services.
 type Bundle struct {
-	*BundleConf
+	BundleConf
 	c *ClusterConf
 	// Nodes contains the set of nodes on which the dataset is currently in use.
 	// The map keys are serials.
@@ -81,7 +81,7 @@ type BundleDataset struct {
 // BundleService is configuration overrides for a service of a bundle and
 // associated bundles.
 type BundleService struct {
-	*ServiceConf
+	ServiceConf
 	Datasets map[string]*ServiceDataset `json:"datasets"`
 }
 
@@ -266,7 +266,7 @@ func (c *ClusterConf) BundleHeartbeat(req *acomm.Request) (interface{}, *url.URL
 func (c *ClusterConf) getBundle(id uint64) (*Bundle, error) {
 	bundle := &Bundle{
 		c:          c,
-		BundleConf: &BundleConf{ID: id},
+		BundleConf: BundleConf{ID: id},
 	}
 	if err := bundle.reload(); err != nil {
 		return nil, err
@@ -287,7 +287,7 @@ func (b *Bundle) reload() error {
 	if !ok {
 		return errors.New("bundle config not found")
 	}
-	if err = json.Unmarshal(config.Data, b.BundleConf); err != nil {
+	if err = json.Unmarshal(config.Data, &b.BundleConf); err != nil {
 		return err
 	}
 	b.ModIndex = config.Index

--- a/providers/clusterconf/bundle_test.go
+++ b/providers/clusterconf/bundle_test.go
@@ -73,7 +73,7 @@ func (s *clusterConf) TestUpdateBundle() {
 			Task: "update-bundle",
 			Args: &clusterconf.BundlePayload{
 				Bundle: &clusterconf.Bundle{
-					BundleConf: &clusterconf.BundleConf{ID: test.id},
+					BundleConf: clusterconf.BundleConf{ID: test.id},
 					ModIndex:   test.modIndex,
 				},
 			},
@@ -184,7 +184,7 @@ func (s *clusterConf) TestBundleHeartbeat() {
 }
 
 func (s *clusterConf) addBundle() (*clusterconf.Bundle, error) {
-	bundle := &clusterconf.Bundle{BundleConf: &clusterconf.BundleConf{
+	bundle := &clusterconf.Bundle{BundleConf: clusterconf.BundleConf{
 		ID: uint64(rand.Int63()),
 		Ports: clusterconf.BundlePorts{
 			1: &clusterconf.BundlePort{

--- a/providers/clusterconf/bundle_test.go
+++ b/providers/clusterconf/bundle_test.go
@@ -207,19 +207,19 @@ func (s *clusterConf) addBundle() (*clusterconf.Bundle, error) {
 	}
 	bundle := &clusterconf.Bundle{BundleConf: clusterconf.BundleConf{
 		ID: uint64(rand.Int63()),
-		Datasets: map[string]*clusterconf.BundleDataset{
-			dataset.ID: &clusterconf.BundleDataset{
+		Datasets: map[string]clusterconf.BundleDataset{
+			dataset.ID: clusterconf.BundleDataset{
 				Name: "foobar",
 				ID:   dataset.ID,
 			},
 		},
-		Services: map[string]*clusterconf.BundleService{
-			service.ID: &clusterconf.BundleService{
+		Services: map[string]clusterconf.BundleService{
+			service.ID: clusterconf.BundleService{
 				ServiceConf: clusterconf.ServiceConf{ID: service.ID},
 			},
 		},
 		Ports: clusterconf.BundlePorts{
-			1: &clusterconf.BundlePort{
+			1: clusterconf.BundlePort{
 				Port: 1,
 			},
 		},

--- a/providers/clusterconf/bundle_test.go
+++ b/providers/clusterconf/bundle_test.go
@@ -208,13 +208,13 @@ func (s *clusterConf) addBundle() (*clusterconf.Bundle, error) {
 	bundle := &clusterconf.Bundle{BundleConf: clusterconf.BundleConf{
 		ID: uint64(rand.Int63()),
 		Datasets: map[string]clusterconf.BundleDataset{
-			dataset.ID: clusterconf.BundleDataset{
+			dataset.ID: {
 				Name: "foobar",
 				ID:   dataset.ID,
 			},
 		},
 		Services: map[string]clusterconf.BundleService{
-			service.ID: clusterconf.BundleService{
+			service.ID: {
 				ServiceConf: clusterconf.ServiceConf{ID: service.ID},
 			},
 		},

--- a/providers/clusterconf/dataset.go
+++ b/providers/clusterconf/dataset.go
@@ -18,7 +18,7 @@ const datasetsPrefix string = "datasets"
 
 // Dataset is information about a dataset.
 type Dataset struct {
-	*DatasetConf
+	DatasetConf
 	c *ClusterConf
 	// Nodes contains the set of nodes on which the dataset is currently in use.
 	// The map keys are IP address strings.
@@ -190,7 +190,7 @@ func (c *ClusterConf) DatasetHeartbeat(req *acomm.Request) (interface{}, *url.UR
 func (c *ClusterConf) getDataset(id string) (*Dataset, error) {
 	dataset := &Dataset{
 		c:           c,
-		DatasetConf: &DatasetConf{ID: id},
+		DatasetConf: DatasetConf{ID: id},
 	}
 	if err := dataset.reload(); err != nil {
 		return nil, err
@@ -211,7 +211,7 @@ func (d *Dataset) reload() error {
 	if !ok {
 		return errors.New("dataset config not found")
 	}
-	if err = json.Unmarshal(config.Data, d.DatasetConf); err != nil {
+	if err = json.Unmarshal(config.Data, &d.DatasetConf); err != nil {
 		return err
 	}
 	d.ModIndex = config.Index

--- a/providers/clusterconf/dataset_test.go
+++ b/providers/clusterconf/dataset_test.go
@@ -174,7 +174,10 @@ func (s *clusterConf) TestDatasetHeartbeat() {
 }
 
 func (s *clusterConf) addDataset() (*clusterconf.Dataset, error) {
-	dataset := &clusterconf.Dataset{DatasetConf: clusterconf.DatasetConf{ID: uuid.New()}}
+	dataset := &clusterconf.Dataset{DatasetConf: clusterconf.DatasetConf{
+		ID:    uuid.New(),
+		Quota: 5,
+	}}
 	datasetKey := path.Join("datasets", dataset.ID, "config")
 	hbKey := path.Join("datasets", dataset.ID, "nodes", "127.0.0.1")
 

--- a/providers/clusterconf/dataset_test.go
+++ b/providers/clusterconf/dataset_test.go
@@ -70,7 +70,7 @@ func (s *clusterConf) TestUpdateDataset() {
 			Task: "update-dataset",
 			Args: &clusterconf.DatasetPayload{
 				Dataset: &clusterconf.Dataset{
-					DatasetConf: &clusterconf.DatasetConf{ID: test.id},
+					DatasetConf: clusterconf.DatasetConf{ID: test.id},
 					ModIndex:    test.modIndex,
 				},
 			},
@@ -174,7 +174,7 @@ func (s *clusterConf) TestDatasetHeartbeat() {
 }
 
 func (s *clusterConf) addDataset() (*clusterconf.Dataset, error) {
-	dataset := &clusterconf.Dataset{DatasetConf: &clusterconf.DatasetConf{ID: uuid.New()}}
+	dataset := &clusterconf.Dataset{DatasetConf: clusterconf.DatasetConf{ID: uuid.New()}}
 	datasetKey := path.Join("datasets", dataset.ID, "config")
 	hbKey := path.Join("datasets", dataset.ID, "nodes", "127.0.0.1")
 

--- a/providers/clusterconf/defaults.go
+++ b/providers/clusterconf/defaults.go
@@ -12,7 +12,7 @@ const defaultsPrefix string = "cluster"
 
 // Defaults is information about the cluster configuration.
 type Defaults struct {
-	*DefaultsConf
+	DefaultsConf
 	c        *ClusterConf
 	ModIndex uint64 `json:"modIndex"`
 }
@@ -57,7 +57,7 @@ func (c *ClusterConf) UpdateDefaults(req *acomm.Request) (interface{}, *url.URL,
 
 func (c *ClusterConf) getDefaults() (*Defaults, error) {
 	defaults := &Defaults{
-		DefaultsConf: &DefaultsConf{},
+		DefaultsConf: DefaultsConf{},
 		c:            c,
 	}
 	if err := defaults.reload(); err != nil {
@@ -75,7 +75,7 @@ func (d *Defaults) reload() error {
 		return err
 	}
 
-	if err := json.Unmarshal(value.Data, d.DefaultsConf); err != nil {
+	if err := json.Unmarshal(value.Data, &d.DefaultsConf); err != nil {
 		return err
 	}
 	d.ModIndex = value.Index

--- a/providers/clusterconf/defaults_test.go
+++ b/providers/clusterconf/defaults_test.go
@@ -44,7 +44,7 @@ func (s *clusterConf) TestUpdateDefaults() {
 			Task: "update-defaults",
 			Args: &clusterconf.DefaultsPayload{
 				Defaults: &clusterconf.Defaults{
-					DefaultsConf: &clusterconf.DefaultsConf{ZFSManual: test.zfsManual},
+					DefaultsConf: clusterconf.DefaultsConf{ZFSManual: test.zfsManual},
 					ModIndex:     *test.modIndex,
 				},
 			},
@@ -74,7 +74,7 @@ func (s *clusterConf) TestUpdateDefaults() {
 }
 
 func (s *clusterConf) setDefaultZFSManual(value bool) (*clusterconf.Defaults, error) {
-	defaults := &clusterconf.Defaults{DefaultsConf: &clusterconf.DefaultsConf{ZFSManual: value}}
+	defaults := &clusterconf.Defaults{DefaultsConf: clusterconf.DefaultsConf{ZFSManual: value}}
 	key := path.Join("cluster")
 	data := map[string]interface{}{
 		key: defaults,

--- a/providers/clusterconf/mock.go
+++ b/providers/clusterconf/mock.go
@@ -64,7 +64,7 @@ func (c *MockClusterConf) RegisterTasks(server *provider.Server) {
 
 // GetBundle retrieves a mock bundle.
 func (c *MockClusterConf) GetBundle(req *acomm.Request) (interface{}, *url.URL, error) {
-	var args BundleIDArgs
+	var args GetBundleArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
 		return nil, nil, err
 	}
@@ -109,7 +109,7 @@ func (c *MockClusterConf) UpdateBundle(req *acomm.Request) (interface{}, *url.UR
 
 // DeleteBundle removes a mock bundle.
 func (c *MockClusterConf) DeleteBundle(req *acomm.Request) (interface{}, *url.URL, error) {
-	var args BundleIDArgs
+	var args DeleteBundleArgs
 	if err := req.UnmarshalArgs(&args); err != nil {
 		return nil, nil, err
 	}

--- a/providers/clusterconf/service.go
+++ b/providers/clusterconf/service.go
@@ -14,7 +14,7 @@ const servicesPrefix string = "services"
 
 // Service is information about a service.
 type Service struct {
-	*ServiceConf
+	ServiceConf
 	c *ClusterConf
 	// ModIndex should be treated as opaque, but passed back on updates
 	ModIndex uint64 `json:"modIndex"`
@@ -111,7 +111,7 @@ func (c *ClusterConf) DeleteService(req *acomm.Request) (interface{}, *url.URL, 
 func (c *ClusterConf) getService(id string) (*Service, error) {
 	service := &Service{
 		c:           c,
-		ServiceConf: &ServiceConf{ID: id},
+		ServiceConf: ServiceConf{ID: id},
 	}
 	if err := service.reload(); err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func (s *Service) reload() error {
 		return err
 	}
 
-	if err := json.Unmarshal(value.Data, s.ServiceConf); err != nil {
+	if err := json.Unmarshal(value.Data, &s.ServiceConf); err != nil {
 		return err
 	}
 	s.ModIndex = value.Index

--- a/providers/clusterconf/service.go
+++ b/providers/clusterconf/service.go
@@ -22,11 +22,11 @@ type Service struct {
 
 // ServiceConf is the configuration of a service.
 type ServiceConf struct {
-	ID           string                  `json:"id"`
-	Dataset      string                  `json:"dataset"`
-	HealthChecks map[string]*HealthCheck `json:"healthChecks"`
-	Limits       *ResourceLimits         `json:"limits"`
-	Env          map[string]string       `json:"env"`
+	ID           string                 `json:"id"`
+	Dataset      string                 `json:"dataset"`
+	HealthChecks map[string]HealthCheck `json:"healthChecks"`
+	Limits       ResourceLimits         `json:"limits"`
+	Env          map[string]string      `json:"env"`
 }
 
 // ResourceLimits is configuration for resource upper bounds.

--- a/providers/clusterconf/service.go
+++ b/providers/clusterconf/service.go
@@ -24,7 +24,7 @@ type Service struct {
 type ServiceConf struct {
 	ID           string                  `json:"id"`
 	Dataset      string                  `json:"dataset"`
-	HealthChecks map[string]*HealthCheck `json:"healthCheck"`
+	HealthChecks map[string]*HealthCheck `json:"healthChecks"`
 	Limits       *ResourceLimits         `json:"limits"`
 	Env          map[string]string       `json:"env"`
 }
@@ -38,9 +38,9 @@ type ResourceLimits struct {
 
 // HealthCheck is configuration for performing a health check.
 type HealthCheck struct {
-	ID               string   `json:"id"`
-	ProtocolProvider string   `json:"protocolProvider"`
-	Parameters       []string `json:"parameters"`
+	ID   string      `json:"id"`
+	Type string      `json:"type"`
+	Args interface{} `json:"args"`
 }
 
 // ServicePayload can be used for task args or result when a service object

--- a/providers/clusterconf/service_test.go
+++ b/providers/clusterconf/service_test.go
@@ -127,7 +127,10 @@ func (s *clusterConf) TestDeleteService() {
 
 func (s *clusterConf) addService() (*clusterconf.Service, error) {
 	// Populate a service
-	service := &clusterconf.Service{ServiceConf: clusterconf.ServiceConf{ID: uuid.New()}}
+	service := &clusterconf.Service{ServiceConf: clusterconf.ServiceConf{
+		ID:      uuid.New(),
+		Dataset: "testds",
+	}}
 	key := path.Join("services", service.ID, "config")
 	data := map[string]interface{}{
 		key: service,

--- a/providers/clusterconf/service_test.go
+++ b/providers/clusterconf/service_test.go
@@ -67,7 +67,7 @@ func (s *clusterConf) TestUpdateService() {
 			Task: "update-service",
 			Args: &clusterconf.ServicePayload{
 				Service: &clusterconf.Service{
-					ServiceConf: &clusterconf.ServiceConf{ID: test.id},
+					ServiceConf: clusterconf.ServiceConf{ID: test.id},
 					ModIndex:    test.modIndex,
 				},
 			},
@@ -127,7 +127,7 @@ func (s *clusterConf) TestDeleteService() {
 
 func (s *clusterConf) addService() (*clusterconf.Service, error) {
 	// Populate a service
-	service := &clusterconf.Service{ServiceConf: &clusterconf.ServiceConf{ID: uuid.New()}}
+	service := &clusterconf.Service{ServiceConf: clusterconf.ServiceConf{ID: uuid.New()}}
 	key := path.Join("services", service.ID, "config")
 	data := map[string]interface{}{
 		key: service,


### PR DESCRIPTION
#### Description:

With a boolean argument, GetBundle and ListBundle will now return the datasets and services with the bundle-specific config overlayed on the base dataset and service configuration. Without the argument, it will return just the bundle-specific config.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #221

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/222)

<!-- Reviewable:end -->
