### PR TITLE
Run errcheck separately from gometalinter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ godocdown:
 .PHONY: lint-required
 lint-required:
 	gometalinter @gometalinter.required.flags
+	# errcheck has been separated here for efficiency.
+	# It has to load all of the files to analyze APIs. When given multiple pkg
+	# paths, it takes advantage of caching after loads. Using gometalinter runs
+	# it separately for each pkg, losing the caching speed benefits.
+	errcheck --verbose $$(go list ./... | grep -v /vendor/)
 
 .PHONY: lint-optional
 lint-optional:

--- a/gometalinter.required.flags
+++ b/gometalinter.required.flags
@@ -1,6 +1,5 @@
 --disable-all
 --enable=goimports
---enable=errcheck
 --enable=vet
 --enable=gofmt
 --enable=golint


### PR DESCRIPTION
#### Description:

To avoid timeouts, handle `errcheck` separately from `gometalinter` when `make lint-required` is run. The `gometalinter` command runs `errcheck` separately for each pkg, which means `errcheck` can't take advantage of caching after loading files for analysis. Loading and analyzing can be a slow process, making the use of caching important.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #225

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/231)

<!-- Reviewable:end -->
