### PR TITLE
Cache spl and zfs after building during travis test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,14 @@ env:
     - VCONSUL=0.6.4
     - VETCD=2.1.1
     - VZFS=0.6.5.5
+    - ZFS_CACHE=/tmp/zfs
+
+cache:
+  directories:
+    - $ZFS_CACHE
 
 # Versions of Go and deps in the build matrix should test the current in use by
-# mistify-os and the latest release.
+# cerana-os and the latest release.
 
 go:
   - 1.5.2
@@ -21,6 +26,7 @@ go:
 
 install:
   - mkdir -p $HOME/bin
+  - mkdir -p $ZFS_CACHE
   - .travis/deps.sh fetch
   - go get -t -v ./...
   - .travis/deps.sh install

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - make lint-required
 
 script:
-  - make test
+  - make test -j $(nproc)
 
 after_success:
   - make lint-optional

--- a/run-test.sh
+++ b/run-test.sh
@@ -7,7 +7,7 @@ set -e
 
 dir=$(dirname $1)
 name=$(basename $1)
-out=$1.run.out
+out="$dir/test.out"
 exec 2> $out
 
 which consul &>/dev/null


### PR DESCRIPTION
#### Description:
1. Avoid rebuilding SPL and ZFS every test run, caching both between `make` and `make install`
2. Fix test output filenames so they're `go clean`able
3. Use the `-j` flag to run concurrent go tests
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #56

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/234)

<!-- Reviewable:end -->
