### PR TITLE
Statpusher comms

### DIFF
--- a/cmd/statspusher/README.md
+++ b/cmd/statspusher/README.md
@@ -6,14 +6,14 @@ Usage:
 
     $ ./statspusher -h
     Usage of ./statspusher:
-    -b, --bundleInterval uint     bundle heartbeat interval (seconds)
+    -b, --bundleInterval uint     bundle heartbeat interval
     -e, --clusterDataURL string   url of coordinator for the cluster information
     -c, --configFile string       path to config file
-    -d, --datasetInterval uint    dataset heartbeat interval (seconds)
+    -d, --datasetInterval uint    dataset heartbeat interval
     -l, --logLevel string         log level: debug/info/warn/error/fatal/panic (default "warning")
     -u, --nodeDataURL string      url of coordinator for node information retrieval
-    -n, --nodeInterval uint       node heartbeat interval (seconds)
-    -r, --requestTimeout uint     default timeout for requests made (seconds)
+    -n, --nodeInterval uint       node heartbeat interval
+    -r, --requestTimeout uint     default timeout for requests made
     Note: Flags can be used in either fooBar or foo[_-.]bar form.
 
 

--- a/cmd/statspusher/README.md
+++ b/cmd/statspusher/README.md
@@ -5,15 +5,15 @@
 Usage:
 
     $ statspusher -h
-    Usage of statspusher
-    -b, --bundleTTL uint          default timeout for requests made (seconds)
-    -c, --configFile string       path to config file
-    -u, --coordinatorURL string   url of coordinator for information retrieval
-    -d, --datasetTTL uint         default timeout for requests made (seconds)
-    -e, --heartbeatURL string     url of coordinator for the heartbeat registering
-    -l, --logLevel string         log level: debug/info/warn/error/fatal/panic (default "warning")
-    -n, --nodeTTL uint            default timeout for requests made  (seconds)
-    -r, --requestTimeout uint     default timeout for requests made (seconds)
+    Usage of statspusher:
+    -b, --bundleTTL uint        bundle heartbeat ttl (seconds)
+    -c, --configFile string     path to config file
+    -d, --datasetTTL uint       dataset heartbeat ttl (seconds)
+    -e, --heartbeatURL string   url of coordinator for the heartbeat registering
+    -l, --logLevel string       log level: debug/info/warn/error/fatal/panic (default "warning")
+    -u, --nodeDataURL string    url of coordinator for node information retrieval
+    -n, --nodeTTL uint          node heartbeat ttl (seconds)
+    -r, --requestTimeout uint   default timeout for requests made (seconds)
     Note: Flags can be used in either fooBar or foo[_-.]bar form.
 
 

--- a/cmd/statspusher/README.md
+++ b/cmd/statspusher/README.md
@@ -5,15 +5,15 @@
 Usage:
 
     $ statspusher -h
-    Usage of statspusher:
-    -b, --bundleTTL uint        bundle heartbeat ttl (seconds)
-    -c, --configFile string     path to config file
-    -d, --datasetTTL uint       dataset heartbeat ttl (seconds)
-    -e, --heartbeatURL string   url of coordinator for the heartbeat registering
-    -l, --logLevel string       log level: debug/info/warn/error/fatal/panic (default "warning")
-    -u, --nodeDataURL string    url of coordinator for node information retrieval
-    -n, --nodeTTL uint          node heartbeat ttl (seconds)
-    -r, --requestTimeout uint   default timeout for requests made (seconds)
+    Usage of ./statspusher:
+    -b, --bundleInterval uint    bundle heartbeat interval (seconds)
+    -c, --configFile string      path to config file
+    -d, --datasetInterval uint   dataset heartbeat interval (seconds)
+    -e, --heartbeatURL string    url of coordinator for the heartbeat registering
+    -l, --logLevel string        log level: debug/info/warn/error/fatal/panic (default "warning")
+    -u, --nodeDataURL string     url of coordinator for node information retrieval
+    -n, --nodeInterval uint      node heartbeat interval (seconds)
+    -r, --requestTimeout uint    default timeout for requests made (seconds)
     Note: Flags can be used in either fooBar or foo[_-.]bar form.
 
 

--- a/cmd/statspusher/README.md
+++ b/cmd/statspusher/README.md
@@ -4,16 +4,16 @@
 
 Usage:
 
-    $ statspusher -h
+    $ ./statspusher -h
     Usage of ./statspusher:
-    -b, --bundleInterval uint    bundle heartbeat interval (seconds)
-    -c, --configFile string      path to config file
-    -d, --datasetInterval uint   dataset heartbeat interval (seconds)
-    -e, --heartbeatURL string    url of coordinator for the heartbeat registering
-    -l, --logLevel string        log level: debug/info/warn/error/fatal/panic (default "warning")
-    -u, --nodeDataURL string     url of coordinator for node information retrieval
-    -n, --nodeInterval uint      node heartbeat interval (seconds)
-    -r, --requestTimeout uint    default timeout for requests made (seconds)
+    -b, --bundleInterval uint     bundle heartbeat interval (seconds)
+    -e, --clusterDataURL string   url of coordinator for the cluster information
+    -c, --configFile string       path to config file
+    -d, --datasetInterval uint    dataset heartbeat interval (seconds)
+    -l, --logLevel string         log level: debug/info/warn/error/fatal/panic (default "warning")
+    -u, --nodeDataURL string      url of coordinator for node information retrieval
+    -n, --nodeInterval uint       node heartbeat interval (seconds)
+    -r, --requestTimeout uint     default timeout for requests made (seconds)
     Note: Flags can be used in either fooBar or foo[_-.]bar form.
 
 

--- a/cmd/statspusher/bundle.go
+++ b/cmd/statspusher/bundle.go
@@ -51,7 +51,7 @@ func (s *statsPusher) getBundles() ([]*clusterconf.Bundle, error) {
 		if err := multiRequest.AddRequest(name, req); err != nil {
 			break
 		}
-		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 			multiRequest.RemoveRequest(req)
 			break
 		}
@@ -99,7 +99,7 @@ func (s *statsPusher) getSerial() (string, error) {
 	if err := s.tracker.TrackRequest(req, s.config.requestTimeout()); err != nil {
 		return "", err
 	}
-	if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+	if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 		return "", err
 	}
 
@@ -141,7 +141,7 @@ func (s *statsPusher) sendBundleHeartbeats(bundles map[uint64]map[string]error, 
 			errored = append(errored, bundle)
 			continue
 		}
-		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 			multiRequest.RemoveRequest(req)
 			errored = append(errored, bundle)
 			continue
@@ -190,7 +190,7 @@ func (s *statsPusher) runHealthChecks(bundles []*clusterconf.Bundle) (map[uint64
 			errors[name] = err
 			continue
 		}
-		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 			multiRequest.RemoveRequest(req)
 			errors[name] = err
 		}

--- a/cmd/statspusher/bundle.go
+++ b/cmd/statspusher/bundle.go
@@ -42,7 +42,7 @@ func (s *statsPusher) getBundles() ([]*clusterconf.Bundle, error) {
 	requests["local"] = localReq
 	knownReq, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:    "list-bundles",
-		TaskURL: s.config.heartbeatURL(),
+		TaskURL: s.config.clusterDataURL(),
 	})
 	requests["known"] = knownReq
 
@@ -123,7 +123,7 @@ func (s *statsPusher) sendBundleHeartbeats(bundles map[uint64]map[string]error, 
 	for bundle, healthErrors := range bundles {
 		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:    "bundle-heartbeat",
-			TaskURL: s.config.heartbeatURL(),
+			TaskURL: s.config.clusterDataURL(),
 			Args: clusterconf.BundleHeartbeatArgs{
 				ID:     bundle,
 				Serial: serial,

--- a/cmd/statspusher/config.go
+++ b/cmd/statspusher/config.go
@@ -29,9 +29,9 @@ type config struct {
 
 // ConfigData defines the structure of the config data (e.g. in the config file)
 type ConfigData struct {
-	CoordinatorURL string `json:"coordinatorURL"`
-	HeartbeatURL   string `json:"heartbeatURL"`
-	LogLevel       string `json:"logLevel"`
+	NodeDataURL  string `json:"nodeDataURL"`
+	HeartbeatURL string `json:"heartbeatURL"`
+	LogLevel     string `json:"logLevel"`
 	// Timeout and TTL values are in seconds
 	RequestTimeout uint `json:"requestTimeout"`
 	DatasetTTL     uint `json:"datasetTTL"`
@@ -59,7 +59,7 @@ func newConfig(flagSet *pflag.FlagSet, v *viper.Viper) *config {
 	}
 
 	flagSet.StringP("configFile", "c", "", "path to config file")
-	flagSet.StringP("coordinatorURL", "u", "", "url of coordinator for information retrieval")
+	flagSet.StringP("nodeDataURL", "u", "", "url of coordinator for node information retrieval")
 	flagSet.StringP("heartbeatURL", "e", "", "url of coordinator for the heartbeat registering")
 	flagSet.StringP("logLevel", "l", "warning", "log level: debug/info/warn/error/fatal/panic")
 	flagSet.Uint64P("requestTimeout", "r", 0, "default timeout for requests made (seconds)")
@@ -130,9 +130,9 @@ func (c *config) loadConfig() error {
 	return c.validate()
 }
 
-func (c *config) coordinatorURL() *url.URL {
+func (c *config) nodeDataURL() *url.URL {
 	// Error checking has been done during validation
-	u, _ := url.ParseRequestURI(c.viper.GetString("coordinatorURL"))
+	u, _ := url.ParseRequestURI(c.viper.GetString("nodeDataURL"))
 	return u
 }
 
@@ -188,7 +188,7 @@ func (c *config) validate() error {
 		return errors.New("request timeout must be > 0")
 	}
 
-	if err := c.validateURL("coordinatorURL"); err != nil {
+	if err := c.validateURL("nodeDataURL"); err != nil {
 		return err
 	}
 	if err := c.validateURL("heartbeatURL"); err != nil {

--- a/cmd/statspusher/config.go
+++ b/cmd/statspusher/config.go
@@ -29,9 +29,9 @@ type config struct {
 
 // ConfigData defines the structure of the config data (e.g. in the config file)
 type ConfigData struct {
-	NodeDataURL  string `json:"nodeDataURL"`
-	HeartbeatURL string `json:"heartbeatURL"`
-	LogLevel     string `json:"logLevel"`
+	NodeDataURL    string `json:"nodeDataURL"`
+	ClusterDataURL string `json:"clusterDataURL"`
+	LogLevel       string `json:"logLevel"`
 	// Timeout and Interval values are in seconds
 	RequestTimeout  uint `json:"requestTimeout"`
 	DatasetInterval uint `json:"datasetInterval"`
@@ -60,7 +60,7 @@ func newConfig(flagSet *pflag.FlagSet, v *viper.Viper) *config {
 
 	flagSet.StringP("configFile", "c", "", "path to config file")
 	flagSet.StringP("nodeDataURL", "u", "", "url of coordinator for node information retrieval")
-	flagSet.StringP("heartbeatURL", "e", "", "url of coordinator for the heartbeat registering")
+	flagSet.StringP("clusterDataURL", "e", "", "url of coordinator for the cluster information")
 	flagSet.StringP("logLevel", "l", "warning", "log level: debug/info/warn/error/fatal/panic")
 	flagSet.Uint64P("requestTimeout", "r", 0, "default timeout for requests made (seconds)")
 	flagSet.Uint64P("datasetInterval", "d", 0, "dataset heartbeat interval (seconds)")
@@ -136,9 +136,9 @@ func (c *config) nodeDataURL() *url.URL {
 	return u
 }
 
-func (c *config) heartbeatURL() *url.URL {
+func (c *config) clusterDataURL() *url.URL {
 	// Error checking has been done during validation
-	u, _ := url.ParseRequestURI(c.viper.GetString("heartbeatURL"))
+	u, _ := url.ParseRequestURI(c.viper.GetString("clusterDataURL"))
 	return u
 }
 
@@ -191,7 +191,7 @@ func (c *config) validate() error {
 	if err := c.validateURL("nodeDataURL"); err != nil {
 		return err
 	}
-	if err := c.validateURL("heartbeatURL"); err != nil {
+	if err := c.validateURL("clusterDataURL"); err != nil {
 		return err
 	}
 

--- a/cmd/statspusher/config.go
+++ b/cmd/statspusher/config.go
@@ -29,14 +29,13 @@ type config struct {
 
 // ConfigData defines the structure of the config data (e.g. in the config file)
 type ConfigData struct {
-	NodeDataURL    string `json:"nodeDataURL"`
-	ClusterDataURL string `json:"clusterDataURL"`
-	LogLevel       string `json:"logLevel"`
-	// Timeout and Interval values are in seconds
-	RequestTimeout  uint `json:"requestTimeout"`
-	DatasetInterval uint `json:"datasetInterval"`
-	BundleInterval  uint `json:"bundleInterval"`
-	NodeInterval    uint `json:"nodeInterval"`
+	NodeDataURL     string `json:"nodeDataURL"`
+	ClusterDataURL  string `json:"clusterDataURL"`
+	LogLevel        string `json:"logLevel"`
+	RequestTimeout  string `json:"requestTimeout"`
+	DatasetInterval string `json:"datasetInterval"`
+	BundleInterval  string `json:"bundleInterval"`
+	NodeInterval    string `json:"nodeInterval"`
 }
 
 func newConfig(flagSet *pflag.FlagSet, v *viper.Viper) *config {
@@ -62,10 +61,10 @@ func newConfig(flagSet *pflag.FlagSet, v *viper.Viper) *config {
 	flagSet.StringP("nodeDataURL", "u", "", "url of coordinator for node information retrieval")
 	flagSet.StringP("clusterDataURL", "e", "", "url of coordinator for the cluster information")
 	flagSet.StringP("logLevel", "l", "warning", "log level: debug/info/warn/error/fatal/panic")
-	flagSet.Uint64P("requestTimeout", "r", 0, "default timeout for requests made (seconds)")
-	flagSet.Uint64P("datasetInterval", "d", 0, "dataset heartbeat interval (seconds)")
-	flagSet.Uint64P("bundleInterval", "b", 0, "bundle heartbeat interval (seconds)")
-	flagSet.Uint64P("nodeInterval", "n", 0, "node heartbeat interval (seconds)")
+	flagSet.DurationP("requestTimeout", "r", 0, "default timeout for requests made")
+	flagSet.DurationP("datasetInterval", "d", 0, "dataset heartbeat interval")
+	flagSet.DurationP("bundleInterval", "b", 0, "bundle heartbeat interval")
+	flagSet.DurationP("nodeInterval", "n", 0, "node heartbeat interval")
 
 	return &config{
 		viper:   v,
@@ -143,23 +142,19 @@ func (c *config) clusterDataURL() *url.URL {
 }
 
 func (c *config) requestTimeout() time.Duration {
-	return time.Second * time.Duration(c.viper.GetInt("requestTimeout"))
+	return c.viper.GetDuration("requestTimeout")
 }
 
 func (c *config) datasetInterval() time.Duration {
-	return c.getInterval("datasetInterval")
+	return c.viper.GetDuration("datasetInterval")
 }
 
 func (c *config) nodeInterval() time.Duration {
-	return c.getInterval("nodeInterval")
+	return c.viper.GetDuration("nodeInterval")
 }
 
 func (c *config) bundleInterval() time.Duration {
-	return c.getInterval("bundleInterval")
-}
-
-func (c *config) getInterval(key string) time.Duration {
-	return time.Second * time.Duration(c.viper.GetInt(key))
+	return c.viper.GetDuration("bundleInterval")
 }
 
 func (c *config) setupLogging() error {
@@ -175,16 +170,16 @@ func (c *config) setupLogging() error {
 }
 
 func (c *config) validate() error {
-	if c.datasetInterval() <= 0 {
+	if c.datasetInterval() == 0 {
 		return errors.New("dataset interval must be > 0")
 	}
-	if c.bundleInterval() <= 0 {
+	if c.bundleInterval() == 0 {
 		return errors.New("bundle interval must be > 0")
 	}
-	if c.nodeInterval() <= 0 {
+	if c.nodeInterval() == 0 {
 		return errors.New("node interval must be > 0")
 	}
-	if c.requestTimeout() <= 0 {
+	if c.requestTimeout() == 0 {
 		return errors.New("request timeout must be > 0")
 	}
 

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -6,8 +6,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
@@ -108,21 +106,21 @@ func (s *StatsPusher) TestValidate() {
 		description     string
 		nodeDataURL     string
 		clusterDataURL  string
-		requestTimeout  uint
-		datasetInterval uint
-		bundleInterval  uint
-		nodeInterval    uint
+		requestTimeout  string
+		datasetInterval string
+		bundleInterval  string
+		nodeInterval    string
 		expectedErr     string
 	}{
-		{"valid", u, u, 5, 4, 3, 2, ""},
-		{"missing nodeDataURL", "", u, 5, 4, 3, 2, "missing nodeDataURL"},
-		{"invalud nodeDataURL", "asdf", u, 5, 4, 3, 2, "invalid nodeDataURL"},
-		{"missing clusterDataURL", u, "", 5, 4, 3, 2, "missing clusterDataURL"},
-		{"invalud clusterDataURL", u, "asdf", 5, 4, 3, 2, "invalid clusterDataURL"},
-		{"invalid request timeout", u, u, 0, 4, 3, 2, "request timeout must be > 0"},
-		{"invalid dataset interval", u, u, 5, 0, 3, 2, "dataset interval must be > 0"},
-		{"invalid bundle interval", u, u, 5, 4, 0, 2, "bundle interval must be > 0"},
-		{"invalid node interval", u, u, 5, 4, 3, 0, "node interval must be > 0"},
+		{"valid", u, u, "5s", "4s", "3s", "2s", ""},
+		{"missing nodeDataURL", "", u, "5s", "4s", "3s", "2s", "missing nodeDataURL"},
+		{"invalud nodeDataURL", "asdf", u, "5s", "4s", "3s", "2s", "invalid nodeDataURL"},
+		{"missing clusterDataURL", u, "", "5s", "4s", "3s", "2s", "missing clusterDataURL"},
+		{"invalud clusterDataURL", u, "asdf", "5s", "4s", "3s", "2s", "invalid clusterDataURL"},
+		{"invalid request timeout", u, u, "0", "4s", "3s", "2s", "request timeout must be > 0"},
+		{"invalid dataset interval", u, u, "5s", "0", "3s", "2s", "dataset interval must be > 0"},
+		{"invalid bundle interval", u, u, "5s", "4s", "0", "2s", "bundle interval must be > 0"},
+		{"invalid node interval", u, u, "5s", "4s", "3s", "0", "node interval must be > 0"},
 	}
 
 	for _, test := range tests {
@@ -164,19 +162,19 @@ func (s *StatsPusher) TestClusterDataURL() {
 }
 
 func (s *StatsPusher) TestRequestTimeout() {
-	s.EqualValues(s.configData.RequestTimeout, s.config.requestTimeout()/time.Second)
+	s.EqualValues(s.configData.RequestTimeout, s.config.requestTimeout().String())
 }
 
 func (s *StatsPusher) TestDatasetInterval() {
-	s.EqualValues(s.configData.DatasetInterval, s.config.datasetInterval()/time.Second)
+	s.EqualValues(s.configData.DatasetInterval, s.config.datasetInterval().String())
 }
 
 func (s *StatsPusher) TestBundleInterval() {
-	s.EqualValues(s.configData.BundleInterval, s.config.bundleInterval()/time.Second)
+	s.EqualValues(s.configData.BundleInterval, s.config.bundleInterval().String())
 }
 
 func (s *StatsPusher) TestNodeInterval() {
-	s.EqualValues(s.configData.NodeInterval, s.config.nodeInterval()/time.Second)
+	s.EqualValues(s.configData.NodeInterval, s.config.nodeInterval().String())
 }
 
 func newTestConfig(setFlags, writeConfig bool, configData *ConfigData) (*config, *pflag.FlagSet, *viper.Viper, *os.File, error) {
@@ -217,16 +215,16 @@ func newTestConfig(setFlags, writeConfig bool, configData *ConfigData) (*config,
 		if err := fs.Set("logLevel", configData.LogLevel); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("requestTimeout", strconv.FormatUint(uint64(configData.RequestTimeout), 10)); err != nil {
+		if err := fs.Set("requestTimeout", configData.RequestTimeout); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("datasetInterval", strconv.FormatUint(uint64(configData.DatasetInterval), 10)); err != nil {
+		if err := fs.Set("datasetInterval", configData.DatasetInterval); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("bundleInterval", strconv.FormatUint(uint64(configData.BundleInterval), 10)); err != nil {
+		if err := fs.Set("bundleInterval", configData.BundleInterval); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("nodeInterval", strconv.FormatUint(uint64(configData.NodeInterval), 10)); err != nil {
+		if err := fs.Set("nodeInterval", configData.NodeInterval); err != nil {
 			return nil, nil, nil, configFile, err
 		}
 	}

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -115,10 +115,10 @@ func (s *StatsPusher) TestValidate() {
 		expectedErr     string
 	}{
 		{"valid", u, u, 5, 4, 3, 2, ""},
-		{"missing coord", "", u, 5, 4, 3, 2, "missing nodeDataURL"},
-		{"invalud coord", "asdf", u, 5, 4, 3, 2, "invalid nodeDataURL"},
-		{"missing heartbeat", u, "", 5, 4, 3, 2, "missing clusterDataURL"},
-		{"invalud heartbeat", u, "asdf", 5, 4, 3, 2, "invalid clusterDataURL"},
+		{"missing nodeDataURL", "", u, 5, 4, 3, 2, "missing nodeDataURL"},
+		{"invalud nodeDataURL", "asdf", u, 5, 4, 3, 2, "invalid nodeDataURL"},
+		{"missing clusterDataURL", u, "", 5, 4, 3, 2, "missing clusterDataURL"},
+		{"invalud clusterDataURL", u, "asdf", 5, 4, 3, 2, "invalid clusterDataURL"},
 		{"invalid request timeout", u, u, 0, 4, 3, 2, "request timeout must be > 0"},
 		{"invalid dataset interval", u, u, 5, 0, 3, 2, "dataset interval must be > 0"},
 		{"invalid bundle interval", u, u, 5, 4, 0, 2, "bundle interval must be > 0"},

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -107,7 +107,7 @@ func (s *StatsPusher) TestValidate() {
 	tests := []struct {
 		description     string
 		nodeDataURL     string
-		heartbeatURL    string
+		clusterDataURL  string
 		requestTimeout  uint
 		datasetInterval uint
 		bundleInterval  uint
@@ -117,8 +117,8 @@ func (s *StatsPusher) TestValidate() {
 		{"valid", u, u, 5, 4, 3, 2, ""},
 		{"missing coord", "", u, 5, 4, 3, 2, "missing nodeDataURL"},
 		{"invalud coord", "asdf", u, 5, 4, 3, 2, "invalid nodeDataURL"},
-		{"missing heartbeat", u, "", 5, 4, 3, 2, "missing heartbeatURL"},
-		{"invalud heartbeat", u, "asdf", 5, 4, 3, 2, "invalid heartbeatURL"},
+		{"missing heartbeat", u, "", 5, 4, 3, 2, "missing clusterDataURL"},
+		{"invalud heartbeat", u, "asdf", 5, 4, 3, 2, "invalid clusterDataURL"},
 		{"invalid request timeout", u, u, 0, 4, 3, 2, "request timeout must be > 0"},
 		{"invalid dataset interval", u, u, 5, 0, 3, 2, "dataset interval must be > 0"},
 		{"invalid bundle interval", u, u, 5, 4, 0, 2, "bundle interval must be > 0"},
@@ -128,7 +128,7 @@ func (s *StatsPusher) TestValidate() {
 	for _, test := range tests {
 		configData := &ConfigData{
 			NodeDataURL:     test.nodeDataURL,
-			HeartbeatURL:    test.heartbeatURL,
+			ClusterDataURL:  test.clusterDataURL,
 			RequestTimeout:  test.requestTimeout,
 			DatasetInterval: test.datasetInterval,
 			BundleInterval:  test.bundleInterval,
@@ -157,10 +157,10 @@ func (s *StatsPusher) TestNodeDataURL() {
 	s.Equal(u, s.config.nodeDataURL())
 }
 
-func (s *StatsPusher) TestHeartbeatURL() {
-	u, err := url.ParseRequestURI(s.configData.HeartbeatURL)
+func (s *StatsPusher) TestClusterDataURL() {
+	u, err := url.ParseRequestURI(s.configData.ClusterDataURL)
 	s.Require().NoError(err)
-	s.Equal(u, s.config.heartbeatURL())
+	s.Equal(u, s.config.clusterDataURL())
 }
 
 func (s *StatsPusher) TestRequestTimeout() {
@@ -211,7 +211,7 @@ func newTestConfig(setFlags, writeConfig bool, configData *ConfigData) (*config,
 		if err := fs.Set("nodeDataURL", configData.NodeDataURL); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("heartbeatURL", configData.HeartbeatURL); err != nil {
+		if err := fs.Set("clusterDataURL", configData.ClusterDataURL); err != nil {
 			return nil, nil, nil, configFile, err
 		}
 		if err := fs.Set("logLevel", configData.LogLevel); err != nil {

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -31,7 +31,7 @@ func (s *StatsPusher) TestCanonicalFlagName() {
 		{"Foo_bar", "fooBar"},
 		{"foo_BAR", "fooBAR"},
 		{"foo_cpu", "fooCPU"},
-		{"foo_ttl", "fooTTL"},
+		{"foo_interval", "fooInterval"},
 		{"foo_cpu", "fooCPU"},
 		{"foo_url", "fooURL"},
 		{"foo_ip", "fooIP"},
@@ -105,14 +105,14 @@ func (s *StatsPusher) TestSetupLogging() {
 func (s *StatsPusher) TestValidate() {
 	u := "unix:///tmp/foobar"
 	tests := []struct {
-		description    string
-		nodeDataURL    string
-		heartbeatURL   string
-		requestTimeout uint
-		datasetTTL     uint
-		bundleTTL      uint
-		nodeTTL        uint
-		expectedErr    string
+		description     string
+		nodeDataURL     string
+		heartbeatURL    string
+		requestTimeout  uint
+		datasetInterval uint
+		bundleInterval  uint
+		nodeInterval    uint
+		expectedErr     string
 	}{
 		{"valid", u, u, 5, 4, 3, 2, ""},
 		{"missing coord", "", u, 5, 4, 3, 2, "missing nodeDataURL"},
@@ -120,19 +120,19 @@ func (s *StatsPusher) TestValidate() {
 		{"missing heartbeat", u, "", 5, 4, 3, 2, "missing heartbeatURL"},
 		{"invalud heartbeat", u, "asdf", 5, 4, 3, 2, "invalid heartbeatURL"},
 		{"invalid request timeout", u, u, 0, 4, 3, 2, "request timeout must be > 0"},
-		{"invalid dataset ttl", u, u, 5, 0, 3, 2, "dataset ttl must be > 0"},
-		{"invalid bundle ttl", u, u, 5, 4, 0, 2, "bundle ttl must be > 0"},
-		{"invalid node ttl", u, u, 5, 4, 3, 0, "node ttl must be > 0"},
+		{"invalid dataset interval", u, u, 5, 0, 3, 2, "dataset interval must be > 0"},
+		{"invalid bundle interval", u, u, 5, 4, 0, 2, "bundle interval must be > 0"},
+		{"invalid node interval", u, u, 5, 4, 3, 0, "node interval must be > 0"},
 	}
 
 	for _, test := range tests {
 		configData := &ConfigData{
-			NodeDataURL:    test.nodeDataURL,
-			HeartbeatURL:   test.heartbeatURL,
-			RequestTimeout: test.requestTimeout,
-			DatasetTTL:     test.datasetTTL,
-			BundleTTL:      test.bundleTTL,
-			NodeTTL:        test.nodeTTL,
+			NodeDataURL:     test.nodeDataURL,
+			HeartbeatURL:    test.heartbeatURL,
+			RequestTimeout:  test.requestTimeout,
+			DatasetInterval: test.datasetInterval,
+			BundleInterval:  test.bundleInterval,
+			NodeInterval:    test.nodeInterval,
 		}
 
 		config, fs, v, _, err := newTestConfig(true, false, configData)
@@ -167,16 +167,16 @@ func (s *StatsPusher) TestRequestTimeout() {
 	s.EqualValues(s.configData.RequestTimeout, s.config.requestTimeout()/time.Second)
 }
 
-func (s *StatsPusher) TestDatasetTTL() {
-	s.EqualValues(s.configData.DatasetTTL, s.config.datasetTTL()/time.Second)
+func (s *StatsPusher) TestDatasetInterval() {
+	s.EqualValues(s.configData.DatasetInterval, s.config.datasetInterval()/time.Second)
 }
 
-func (s *StatsPusher) TestBundleTTL() {
-	s.EqualValues(s.configData.BundleTTL, s.config.bundleTTL()/time.Second)
+func (s *StatsPusher) TestBundleInterval() {
+	s.EqualValues(s.configData.BundleInterval, s.config.bundleInterval()/time.Second)
 }
 
-func (s *StatsPusher) TestNodeTTL() {
-	s.EqualValues(s.configData.NodeTTL, s.config.nodeTTL()/time.Second)
+func (s *StatsPusher) TestNodeInterval() {
+	s.EqualValues(s.configData.NodeInterval, s.config.nodeInterval()/time.Second)
 }
 
 func newTestConfig(setFlags, writeConfig bool, configData *ConfigData) (*config, *pflag.FlagSet, *viper.Viper, *os.File, error) {
@@ -220,13 +220,13 @@ func newTestConfig(setFlags, writeConfig bool, configData *ConfigData) (*config,
 		if err := fs.Set("requestTimeout", strconv.FormatUint(uint64(configData.RequestTimeout), 10)); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("datasetTTL", strconv.FormatUint(uint64(configData.DatasetTTL), 10)); err != nil {
+		if err := fs.Set("datasetInterval", strconv.FormatUint(uint64(configData.DatasetInterval), 10)); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("bundleTTL", strconv.FormatUint(uint64(configData.BundleTTL), 10)); err != nil {
+		if err := fs.Set("bundleInterval", strconv.FormatUint(uint64(configData.BundleInterval), 10)); err != nil {
 			return nil, nil, nil, configFile, err
 		}
-		if err := fs.Set("nodeTTL", strconv.FormatUint(uint64(configData.NodeTTL), 10)); err != nil {
+		if err := fs.Set("nodeInterval", strconv.FormatUint(uint64(configData.NodeInterval), 10)); err != nil {
 			return nil, nil, nil, configFile, err
 		}
 	}

--- a/cmd/statspusher/config_test.go
+++ b/cmd/statspusher/config_test.go
@@ -106,7 +106,7 @@ func (s *StatsPusher) TestValidate() {
 	u := "unix:///tmp/foobar"
 	tests := []struct {
 		description    string
-		coordinatorURL string
+		nodeDataURL    string
 		heartbeatURL   string
 		requestTimeout uint
 		datasetTTL     uint
@@ -115,8 +115,8 @@ func (s *StatsPusher) TestValidate() {
 		expectedErr    string
 	}{
 		{"valid", u, u, 5, 4, 3, 2, ""},
-		{"missing coord", "", u, 5, 4, 3, 2, "missing coordinatorURL"},
-		{"invalud coord", "asdf", u, 5, 4, 3, 2, "invalid coordinatorURL"},
+		{"missing coord", "", u, 5, 4, 3, 2, "missing nodeDataURL"},
+		{"invalud coord", "asdf", u, 5, 4, 3, 2, "invalid nodeDataURL"},
 		{"missing heartbeat", u, "", 5, 4, 3, 2, "missing heartbeatURL"},
 		{"invalud heartbeat", u, "asdf", 5, 4, 3, 2, "invalid heartbeatURL"},
 		{"invalid request timeout", u, u, 0, 4, 3, 2, "request timeout must be > 0"},
@@ -127,7 +127,7 @@ func (s *StatsPusher) TestValidate() {
 
 	for _, test := range tests {
 		configData := &ConfigData{
-			CoordinatorURL: test.coordinatorURL,
+			NodeDataURL:    test.nodeDataURL,
 			HeartbeatURL:   test.heartbeatURL,
 			RequestTimeout: test.requestTimeout,
 			DatasetTTL:     test.datasetTTL,
@@ -151,10 +151,10 @@ func (s *StatsPusher) TestValidate() {
 	}
 }
 
-func (s *StatsPusher) TestCoordinatorURL() {
-	u, err := url.ParseRequestURI(s.configData.CoordinatorURL)
+func (s *StatsPusher) TestNodeDataURL() {
+	u, err := url.ParseRequestURI(s.configData.NodeDataURL)
 	s.Require().NoError(err)
-	s.Equal(u, s.config.coordinatorURL())
+	s.Equal(u, s.config.nodeDataURL())
 }
 
 func (s *StatsPusher) TestHeartbeatURL() {
@@ -208,7 +208,7 @@ func newTestConfig(setFlags, writeConfig bool, configData *ConfigData) (*config,
 	}
 
 	if setFlags {
-		if err := fs.Set("coordinatorURL", configData.CoordinatorURL); err != nil {
+		if err := fs.Set("nodeDataURL", configData.NodeDataURL); err != nil {
 			return nil, nil, nil, configFile, err
 		}
 		if err := fs.Set("heartbeatURL", configData.HeartbeatURL); err != nil {

--- a/cmd/statspusher/dataset.go
+++ b/cmd/statspusher/dataset.go
@@ -33,7 +33,7 @@ func (s *statsPusher) getDatasets() ([]string, error) {
 	requests["local"] = localReq
 	knownReq, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:    "list-datasets",
-		TaskURL: s.config.heartbeatURL(),
+		TaskURL: s.config.clusterDataURL(),
 	})
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (s *statsPusher) sendDatasetHeartbeats(datasets []string, ip net.IP) error 
 	for _, dataset := range datasets {
 		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task:    "dataset-heartbeat",
-			TaskURL: s.config.heartbeatURL(),
+			TaskURL: s.config.clusterDataURL(),
 			Args: clusterconf.DatasetHeartbeatArgs{
 				ID: dataset,
 				IP: ip,

--- a/cmd/statspusher/dataset.go
+++ b/cmd/statspusher/dataset.go
@@ -45,7 +45,7 @@ func (s *statsPusher) getDatasets() ([]string, error) {
 		if err := multiRequest.AddRequest(name, req); err != nil {
 			break
 		}
-		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 			multiRequest.RemoveRequest(req)
 			break
 		}
@@ -101,7 +101,7 @@ func (s *statsPusher) getIP() (net.IP, error) {
 	if err := s.tracker.TrackRequest(req, s.config.requestTimeout()); err != nil {
 		return nil, err
 	}
-	if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+	if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 		return nil, err
 	}
 
@@ -145,7 +145,7 @@ func (s *statsPusher) sendDatasetHeartbeats(datasets []string, ip net.IP) error 
 			errored = true
 			continue
 		}
-		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 			multiRequest.RemoveRequest(req)
 			errored = true
 			continue

--- a/cmd/statspusher/doc.go
+++ b/cmd/statspusher/doc.go
@@ -1,15 +1,15 @@
 /*
 Usage:
-	$ statspusher -h
+	$ ./statspusher -h
 	Usage of ./statspusher:
-	-b, --bundleInterval uint    bundle heartbeat interval (seconds)
-	-c, --configFile string      path to config file
-	-d, --datasetInterval uint   dataset heartbeat interval (seconds)
-	-e, --heartbeatURL string    url of coordinator for the heartbeat registering
-	-l, --logLevel string        log level: debug/info/warn/error/fatal/panic (default "warning")
-	-u, --nodeDataURL string     url of coordinator for node information retrieval
-	-n, --nodeInterval uint      node heartbeat interval (seconds)
-	-r, --requestTimeout uint    default timeout for requests made (seconds)
+	-b, --bundleInterval uint     bundle heartbeat interval (seconds)
+	-e, --clusterDataURL string   url of coordinator for the cluster information
+	-c, --configFile string       path to config file
+	-d, --datasetInterval uint    dataset heartbeat interval (seconds)
+	-l, --logLevel string         log level: debug/info/warn/error/fatal/panic (default "warning")
+	-u, --nodeDataURL string      url of coordinator for node information retrieval
+	-n, --nodeInterval uint       node heartbeat interval (seconds)
+	-r, --requestTimeout uint     default timeout for requests made (seconds)
 	Note: Flags can be used in either fooBar or foo[_-.]bar form.
 */
 package main

--- a/cmd/statspusher/doc.go
+++ b/cmd/statspusher/doc.go
@@ -1,15 +1,15 @@
 /*
 Usage:
 	$ statspusher -h
-	Usage of statspusher
-	-b, --bundleTTL uint          default timeout for requests made (seconds)
-	-c, --configFile string       path to config file
-	-u, --coordinatorURL string   url of coordinator for information retrieval
-	-d, --datasetTTL uint         default timeout for requests made (seconds)
-	-e, --heartbeatURL string     url of coordinator for the heartbeat registering
-	-l, --logLevel string         log level: debug/info/warn/error/fatal/panic (default "warning")
-	-n, --nodeTTL uint            default timeout for requests made  (seconds)
-	-r, --requestTimeout uint     default timeout for requests made (seconds)
+	Usage of statspusher:
+	-b, --bundleTTL uint        bundle heartbeat ttl (seconds)
+	-c, --configFile string     path to config file
+	-d, --datasetTTL uint       dataset heartbeat ttl (seconds)
+	-e, --heartbeatURL string   url of coordinator for the heartbeat registering
+	-l, --logLevel string       log level: debug/info/warn/error/fatal/panic (default "warning")
+	-u, --nodeDataURL string    url of coordinator for node information retrieval
+	-n, --nodeTTL uint          node heartbeat ttl (seconds)
+	-r, --requestTimeout uint   default timeout for requests made (seconds)
 	Note: Flags can be used in either fooBar or foo[_-.]bar form.
 */
 package main

--- a/cmd/statspusher/doc.go
+++ b/cmd/statspusher/doc.go
@@ -1,15 +1,15 @@
 /*
 Usage:
 	$ statspusher -h
-	Usage of statspusher:
-	-b, --bundleTTL uint        bundle heartbeat ttl (seconds)
-	-c, --configFile string     path to config file
-	-d, --datasetTTL uint       dataset heartbeat ttl (seconds)
-	-e, --heartbeatURL string   url of coordinator for the heartbeat registering
-	-l, --logLevel string       log level: debug/info/warn/error/fatal/panic (default "warning")
-	-u, --nodeDataURL string    url of coordinator for node information retrieval
-	-n, --nodeTTL uint          node heartbeat ttl (seconds)
-	-r, --requestTimeout uint   default timeout for requests made (seconds)
+	Usage of ./statspusher:
+	-b, --bundleInterval uint    bundle heartbeat interval (seconds)
+	-c, --configFile string      path to config file
+	-d, --datasetInterval uint   dataset heartbeat interval (seconds)
+	-e, --heartbeatURL string    url of coordinator for the heartbeat registering
+	-l, --logLevel string        log level: debug/info/warn/error/fatal/panic (default "warning")
+	-u, --nodeDataURL string     url of coordinator for node information retrieval
+	-n, --nodeInterval uint      node heartbeat interval (seconds)
+	-r, --requestTimeout uint    default timeout for requests made (seconds)
 	Note: Flags can be used in either fooBar or foo[_-.]bar form.
 */
 package main

--- a/cmd/statspusher/node.go
+++ b/cmd/statspusher/node.go
@@ -95,7 +95,7 @@ func (s *statsPusher) sendNodeHeartbeat(data *clusterconf.Node) error {
 	}
 	req, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:           "node-heartbeat",
-		TaskURL:        s.config.heartbeatURL(),
+		TaskURL:        s.config.clusterDataURL(),
 		ResponseHook:   s.tracker.URL(),
 		Args:           &clusterconf.NodePayload{Node: data},
 		SuccessHandler: rh,

--- a/cmd/statspusher/node.go
+++ b/cmd/statspusher/node.go
@@ -43,7 +43,7 @@ func (s *statsPusher) getNodeInfo() (*clusterconf.Node, error) {
 			fmt.Println("failed to add")
 			break
 		}
-		if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+		if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 			fmt.Println(name, err)
 			multiRequest.RemoveRequest(req)
 			break
@@ -108,7 +108,7 @@ func (s *statsPusher) sendNodeHeartbeat(data *clusterconf.Node) error {
 	if err := s.tracker.TrackRequest(req, s.config.requestTimeout()); err != nil {
 		return err
 	}
-	if err := acomm.Send(s.config.coordinatorURL(), req); err != nil {
+	if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
 		_ = s.tracker.RemoveRequest(req)
 		return err
 	}

--- a/cmd/statspusher/node.go
+++ b/cmd/statspusher/node.go
@@ -95,7 +95,6 @@ func (s *statsPusher) sendNodeHeartbeat(data *clusterconf.Node) error {
 	}
 	req, err := acomm.NewRequest(acomm.RequestOptions{
 		Task:           "node-heartbeat",
-		TaskURL:        s.config.clusterDataURL(),
 		ResponseHook:   s.tracker.URL(),
 		Args:           &clusterconf.NodePayload{Node: data},
 		SuccessHandler: rh,
@@ -108,7 +107,7 @@ func (s *statsPusher) sendNodeHeartbeat(data *clusterconf.Node) error {
 	if err := s.tracker.TrackRequest(req, s.config.requestTimeout()); err != nil {
 		return err
 	}
-	if err := acomm.Send(s.config.nodeDataURL(), req); err != nil {
+	if err := acomm.Send(s.config.clusterDataURL(), req); err != nil {
 		_ = s.tracker.RemoveRequest(req)
 		return err
 	}

--- a/cmd/statspusher/statspusher.go
+++ b/cmd/statspusher/statspusher.go
@@ -35,9 +35,9 @@ func (s *statsPusher) run() error {
 	if err := s.tracker.Start(); err != nil {
 		return err
 	}
-	s.startHeartbeat("node", s.nodeHeartbeat, s.config.nodeTTL())
-	s.startHeartbeat("dataset", s.datasetHeartbeats, s.config.datasetTTL())
-	s.startHeartbeat("bundle", s.bundleHeartbeats, s.config.bundleTTL())
+	s.startHeartbeat("node", s.nodeHeartbeat, s.config.nodeInterval())
+	s.startHeartbeat("dataset", s.datasetHeartbeats, s.config.datasetInterval())
+	s.startHeartbeat("bundle", s.bundleHeartbeats, s.config.bundleInterval())
 	return nil
 }
 

--- a/cmd/statspusher/statspusher_test.go
+++ b/cmd/statspusher/statspusher_test.go
@@ -51,10 +51,10 @@ func (s *StatsPusher) SetupSuite() {
 		NodeDataURL:     nodeDataURL,
 		ClusterDataURL:  nodeDataURL,
 		LogLevel:        "fatal",
-		RequestTimeout:  5,
-		DatasetInterval: 4,
-		BundleInterval:  3,
-		NodeInterval:    2,
+		RequestTimeout:  "5s",
+		DatasetInterval: "4s",
+		BundleInterval:  "3s",
+		NodeInterval:    "2s",
 	}
 
 	s.config, _, _, s.configFile, err = newTestConfig(false, true, s.configData)

--- a/cmd/statspusher/statspusher_test.go
+++ b/cmd/statspusher/statspusher_test.go
@@ -48,13 +48,13 @@ func (s *StatsPusher) SetupSuite() {
 
 	nodeDataURL := s.coordinator.NewProviderViper().GetString("coordinator_url")
 	s.configData = &ConfigData{
-		NodeDataURL:    nodeDataURL,
-		HeartbeatURL:   nodeDataURL,
-		LogLevel:       "fatal",
-		RequestTimeout: 5,
-		DatasetTTL:     4,
-		BundleTTL:      3,
-		NodeTTL:        2,
+		NodeDataURL:     nodeDataURL,
+		HeartbeatURL:    nodeDataURL,
+		LogLevel:        "fatal",
+		RequestTimeout:  5,
+		DatasetInterval: 4,
+		BundleInterval:  3,
+		NodeInterval:    2,
 	}
 
 	s.config, _, _, s.configFile, err = newTestConfig(false, true, s.configData)

--- a/cmd/statspusher/statspusher_test.go
+++ b/cmd/statspusher/statspusher_test.go
@@ -49,7 +49,7 @@ func (s *StatsPusher) SetupSuite() {
 	nodeDataURL := s.coordinator.NewProviderViper().GetString("coordinator_url")
 	s.configData = &ConfigData{
 		NodeDataURL:     nodeDataURL,
-		HeartbeatURL:    nodeDataURL,
+		ClusterDataURL:  nodeDataURL,
 		LogLevel:        "fatal",
 		RequestTimeout:  5,
 		DatasetInterval: 4,

--- a/cmd/statspusher/statspusher_test.go
+++ b/cmd/statspusher/statspusher_test.go
@@ -46,10 +46,10 @@ func (s *StatsPusher) SetupSuite() {
 	s.coordinator, err = test.NewCoordinator("")
 	noError(err)
 
-	coordinatorURL := s.coordinator.NewProviderViper().GetString("coordinator_url")
+	nodeDataURL := s.coordinator.NewProviderViper().GetString("coordinator_url")
 	s.configData = &ConfigData{
-		CoordinatorURL: coordinatorURL,
-		HeartbeatURL:   coordinatorURL,
+		NodeDataURL:    nodeDataURL,
+		HeartbeatURL:   nodeDataURL,
 		LogLevel:       "fatal",
 		RequestTimeout: 5,
 		DatasetTTL:     4,


### PR DESCRIPTION
#### Description:

Rework the `statspusher` to communicate directly with the L1/node coordinator and the L2/cluster coordinator
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #235

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/238)

<!-- Reviewable:end -->
