### PR TITLE
Travis tweaks v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ cache:
 # cerana-os and the latest release.
 
 go:
-  - 1.5.2
-  - 1.6
+  - 1.6.2
+  - tip
 
 install:
   - mkdir -p $HOME/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - KV=consul
     - VCONSUL=0.6.4
     - VETCD=2.1.1
+    - VGLIDE=0.10.2
     - VZFS=0.6.5.5
     - ZFS_CACHE=/tmp/zfs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - mkdir -p $HOME/bin
   - mkdir -p $ZFS_CACHE
   - .travis/deps.sh fetch
-  - go get -t -v ./...
+  - glide install
   - .travis/deps.sh install
   - sudo modprobe zfs
 

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -31,6 +31,9 @@ function fetch() {
     curl -L "https://github.com/coreos/etcd/releases/download/v$VETCD/etcd-v$VETCD-linux-amd64.tar.gz" \
         | bsdtar -xf- -C$HOME/bin --strip-components=1 etcd-v$VETCD-linux-amd64/etcd
 
+    curl -L "https://github.com/Masterminds/glide/releases/download/$VGLIDE/glide-$VGLIDE-linux-amd64.tar.gz" \
+        | bsdtar -xf- -C$HOME/bin --strip-components=1 linux-amd64/glide
+
     go get github.com/alecthomas/gometalinter
     gometalinter --install --update
 }

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -4,40 +4,39 @@ set -e
 
 export MAKEFLAGS="-j$((2 * $(nproc) + 1))"
 
-function fetch {
-	sudo apt-get update
-	sudo apt-get -q -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" install \
-		autoconf \
-		bsdtar \
-		dh-autoreconf \
-		docker-engine \
-		linux-headers-$(uname -r) \
-		realpath \
-		tree \
-		uuid-dev \
-		zlib1g-dev \
-		;
+function fetch() {
+    sudo apt-get update
+    sudo apt-get -q -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" install \
+        autoconf \
+        bsdtar \
+        dh-autoreconf \
+        docker-engine \
+        linux-headers-$(uname -r) \
+        realpath \
+        tree \
+        uuid-dev \
+        zlib1g-dev
 
-	cd /tmp
+    cd /tmp
     if [ ! -d "$ZFS_CACHE/spl-$VZFS" ]; then
-	    curl -L https://github.com/zfsonlinux/zfs/releases/download/zfs-$VZFS/spl-$VZFS.tar.gz | bsdtar -xf- -C $ZFS_CACHE
+        curl -L https://github.com/zfsonlinux/zfs/releases/download/zfs-$VZFS/spl-$VZFS.tar.gz | bsdtar -xf- -C $ZFS_CACHE
     fi
     if [ ! -d "$ZFS_CACHE/zfs-$CZFS" ]; then
-	    curl -L https://github.com/zfsonlinux/zfs/archive/$CZFS.tar.gz | bsdtar -xf- -C $ZFS_CACHE
+        curl -L https://github.com/zfsonlinux/zfs/archive/$CZFS.tar.gz | bsdtar -xf- -C $ZFS_CACHE
     fi
 
-	curl -L "https://releases.hashicorp.com/consul/$VCONSUL/consul_${VCONSUL}_linux_amd64.zip" | bsdtar -xf- -C$HOME/bin
-	chmod +x $HOME/bin/consul
+    curl -L "https://releases.hashicorp.com/consul/$VCONSUL/consul_${VCONSUL}_linux_amd64.zip" | bsdtar -xf- -C$HOME/bin
+    chmod +x $HOME/bin/consul
 
-	curl -L "https://github.com/coreos/etcd/releases/download/v$VETCD/etcd-v$VETCD-linux-amd64.tar.gz" | \
-		bsdtar -xf- -C$HOME/bin --strip-components=1 etcd-v$VETCD-linux-amd64/etcd
+    curl -L "https://github.com/coreos/etcd/releases/download/v$VETCD/etcd-v$VETCD-linux-amd64.tar.gz" \
+        | bsdtar -xf- -C$HOME/bin --strip-components=1 etcd-v$VETCD-linux-amd64/etcd
 
-	go get github.com/alecthomas/gometalinter
-	gometalinter --install --update
+    go get github.com/alecthomas/gometalinter
+    gometalinter --install --update
 }
 
-function install {
-	cd $ZFS_CACHE
+function install() {
+    cd $ZFS_CACHE
     BUILT_FILE="$ZFS_CACHE/built-$VZFS-$CZFS"
 
     BUILT=0
@@ -50,40 +49,39 @@ function install {
 
     if [ $BUILT -eq 0 ]; then
         (
-        cd spl-$VZFS
-        ./configure --prefix=/usr
-        make
+            cd spl-$VZFS
+            ./configure --prefix=/usr
+            make
         )
     fi
 
     (
-    cd spl-$VZFS
-	sudo make install
-	)
+        cd spl-$VZFS
+        sudo make install
+    )
 
     if [ $BUILT -eq 0 ]; then
         (
-        cd zfs-$CZFS
-        ./autogen.sh
-        ./configure --prefix=/usr --with-spl=/usr/src/spl-$VZFS
-        make
+            cd zfs-$CZFS
+            ./autogen.sh
+            ./configure --prefix=/usr --with-spl=/usr/src/spl-$VZFS
+            make
         )
     fi
-    
+
     (
-    cd zfs-$CZFS
-    sudo make install
+        cd zfs-$CZFS
+        sudo make install
     )
 
-    uname -rv > "$BUILT_FILE"
+    uname -rv >"$BUILT_FILE"
 }
 
 case $1 in
-	fetch|install)
-		;;
-	*)
-		echo "unknown action: $1" >&2
-		exit 1
-		;;
+    fetch | install) ;;
+    *)
+        echo "unknown action: $1" >&2
+        exit 1
+        ;;
 esac
 $1

--- a/glide.lock
+++ b/glide.lock
@@ -1,23 +1,23 @@
-hash: d652286d3856d39d96ee1f55fe6d4801bde30625b8a6da2d1440a01291f452fc
-updated: 2016-06-01T21:04:08.865853833Z
+hash: 19c0aa7bc763c75596579a2737d35e0cf96f3a6a18420db194042ae36291e423
+updated: 2016-06-20T15:13:05.879407402-04:00
 imports:
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
 - name: github.com/coreos/etcd
-  version: fb64c8ccfeb9408b80c3f657a52ec6cad2fdb3f8
+  version: ffd1fa6f52dd17332ec5849d1af3314828a6bd56
   subpackages:
   - error
 - name: github.com/coreos/go-etcd
-  version: 003851be7bb0694fe3cc457a49529a19388ee7cf
+  version: f02171fbd43c7b9b53ce8679b03235a1ef3c7b12
   subpackages:
   - etcd
 - name: github.com/coreos/go-systemd
-  version: 7b2428fec40033549c68f54e26e89e7ca9a9ce31
+  version: 6dc8b843c670f2027cc26b164935635840a40526
   subpackages:
   - dbus
   - unit
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 2df174808ee097f90d259e432cc04442cf60be21
   subpackages:
   - spew
 - name: github.com/davecgh/go-xdr
@@ -31,14 +31,14 @@ imports:
 - name: github.com/godbus/dbus
   version: d40f8873baf2c51e569484fd212d0667c54aa343
 - name: github.com/hashicorp/consul
-  version: b43f900766ad92eebbd5a8f931fe0fe244f9969d
+  version: 26a0ef8c41aa2252ab4cf0844fc6470c8e1d8256
   subpackages:
   - api
   - watch
 - name: github.com/hashicorp/go-cleanhttp
-  version: ad28ea4487f05916463e2423a55166280e8254b5
+  version: 875fb671b3ddc66f8e2f0acc33829c8cb989a38d
 - name: github.com/hashicorp/hcl
-  version: 2604f3bda7e8960c1be1063709e7d7f0765048d0
+  version: 578dd9746824a54637686b51a41bad457a56bcef
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -49,9 +49,10 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/serf
-  version: b60a6d928fe726a588f79a1d500582507f9d79de
+  version: e4ec8cc423bbe20d26584b96efbeb9102e16d05f
   subpackages:
   - coordinate
+  - serf
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/kr/pretty
@@ -61,17 +62,17 @@ imports:
 - name: github.com/magiconair/properties
   version: c265cfa48dda6474e208715ca93e987829f572f8
 - name: github.com/mistifyio/go-zfs
-  version: 67e6c1df1c39c396e50d3a2770c8902888702b3e
+  version: cdc0f941c4d0e0e94d85348285568d921891e138
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - name: github.com/pborman/uuid
-  version: c55201b036063326c5b1b89ccfe45a184973d073
+  version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/shirou/gopsutil
-  version: e8f7a95747d711f34ddfe9dd9b825a84bd059dec
+  version: 22a03b5be3f384f558742929065778aa26471033
   subpackages:
   - cpu
   - disk
@@ -98,17 +99,13 @@ imports:
 - name: github.com/StackExchange/wmi
   version: f3e2bae1e0cb5aef83e319133eabfee30013a4a5
 - name: github.com/stretchr/testify
-  version: 8d64eb7173c7753d6419fd4a9caf057398611364
+  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
   subpackages:
   - suite
   - assert
   - require
 - name: github.com/tylerb/graceful
-  version: 9a3d4236b03bb5d26f7951134d248f9d5510d599
-- name: github.com/ugorji/go
-  version: b94837a2404ab90efe9289e77a70694c355739cb
-  subpackages:
-  - codec
+  version: ecde8c8f16df93a994dda8936c8f60f0c26c28ab
 - name: golang.org/x/net
   version: e45385e9b226f570b1f086bf287b25d3d4117776
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 19c0aa7bc763c75596579a2737d35e0cf96f3a6a18420db194042ae36291e423
-updated: 2016-06-20T15:13:05.879407402-04:00
+hash: a086486ea7d5d97c804603bc32b4f98553713d0edc8708944c5c6eac564a1e23
+updated: 2016-06-22T14:18:21.760594837-04:00
 imports:
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
@@ -62,7 +62,7 @@ imports:
 - name: github.com/magiconair/properties
   version: c265cfa48dda6474e208715ca93e987829f572f8
 - name: github.com/mistifyio/go-zfs
-  version: cdc0f941c4d0e0e94d85348285568d921891e138
+  version: 22c9b32c84eb0d0c6f4043b6e90fc94073de92fa
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - name: github.com/pborman/uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,17 +1,35 @@
 package: github.com/cerana/cerana
 import:
 - package: github.com/Sirupsen/logrus
+  version: ^0.10.0
+- package: github.com/coreos/etcd
+  version: ~2.1.1
+  subpackages:
+  - error
+- package: github.com/coreos/go-etcd
+  version: ~2.1.1
+  subpackages:
+  - etcd
 - package: github.com/coreos/go-systemd
+  version: ^9.0.0
   subpackages:
   - dbus
   - unit
 - package: github.com/davecgh/go-xdr
   subpackages:
   - xdr2
+- package: github.com/hashicorp/consul
+  version: ^0.6.4
+  subpackages:
+  - api
+  - watch
 - package: github.com/mistifyio/go-zfs
+  version: ^2.1.1
 - package: github.com/mitchellh/mapstructure
 - package: github.com/pborman/uuid
+  version: ^1.0.0
 - package: github.com/shirou/gopsutil
+  version: ^2.1.0
   subpackages:
   - cpu
   - disk
@@ -22,5 +40,10 @@ import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/pflag
 - package: github.com/spf13/viper
+- package: github.com/stretchr/testify
+  version: ^1.1.3
+  subpackages:
+  - suite
 - package: github.com/tylerb/graceful
+  version: ^1.2.8
 - package: gopkg.in/tomb.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,7 +24,7 @@ import:
   - api
   - watch
 - package: github.com/mistifyio/go-zfs
-  version: ^2.1.1
+  version: 22c9b32
 - package: github.com/mitchellh/mapstructure
 - package: github.com/pborman/uuid
   version: ^1.0.0

--- a/providers/metrics/mock.go
+++ b/providers/metrics/mock.go
@@ -152,7 +152,7 @@ func NewMockMetrics() *MockMetrics {
 						MTU:          1500,
 						HardwareAddr: "en0",
 						Addrs: []net.InterfaceAddr{
-							{"123.123.123.123"},
+							{Addr: "123.123.123.123"},
 						},
 					},
 				},


### PR DESCRIPTION
#### Description:

use `glide install`
update vendored `go-zfs`
drop go 1.5 from travis and add tip.
fix a go vet error when running under tip
#### Issues affected:

tests for #233

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/240)

<!-- Reviewable:end -->
