### PR TITLE
Updated for the new path on S3 which is a result of configuring the

### DIFF
--- a/boot/bin/cerana-update-dev-platform
+++ b/boot/bin/cerana-update-dev-platform
@@ -2,7 +2,7 @@
 
 BUCKET=https://omniti-cerana-artifacts.s3.amazonaws.com/
 
-INITRD=$(curl "$BUCKET?prefix=CeranaOS/build-cerana/" | sed 's|><|>\n<|g' | grep initrd | tail -n 1 | sed 's|<[^>]*>||g')
+INITRD=$(curl "$BUCKET?prefix=CeranaOS/jobs/build-cerana/" | sed 's|><|>\n<|g' | grep initrd | tail -n 1 | sed 's|<[^>]*>||g' | cut -d '.' -f 1)
 BUILD=${INITRD#*build-cerana/}
 BUILD="${BUILD%%/*}"
 mkdir "/data/platform/${BUILD}" \


### PR DESCRIPTION
#### Description:
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves part of #270 and #271

Jenkins build job for the S3 plugin to manage the artifacts.
This also ignores the .md5 extension for the md5 signature file now
part of the build artifacts.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/275)

<!-- Reviewable:end -->
