### PR TITLE
Temporary fix for statspusher logging - log the error at the top

### DIFF
--- a/cmd/statspusher/main.go
+++ b/cmd/statspusher/main.go
@@ -24,6 +24,6 @@ func main() {
 
 func dieOnError(err error) {
 	if err != nil {
-		logrus.Fatal("encountered an error during startup")
+		logrus.WithField("error", err).Fatal("encountered an error during startup")
 	}
 }


### PR DESCRIPTION
#### Description:

Quick fix for statspusher error logging. Log the error at the top. Will need to revisit eventually to make sure it's not double logging and that everything is eventually getting logged.
#### Issues affected:
#232

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/286)

<!-- Reviewable:end -->
