### PR TITLE
basic cluster bootstrap platform downloading

### DIFF
--- a/boot/scripts/copy-platform.sh
+++ b/boot/scripts/copy-platform.sh
@@ -1,19 +1,65 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # shellcheck disable=SC1091
 source /tmp/cerana-bootcfg
 
-if [[ -L /dev/disk/by-label/CERANA ]]; then
+# Don't do this in rescue mode
+[[ -n $CERANA_RESCUE ]] && exit 0
+
+verify_existing() {
+    [[ -n "${CERANA_INITRD_HASH}" ]] || return 1 # no checksum to verify
+    DESTINATION="/data/platform/${CERANA_INITRD_HASH}"
+    IFS=- read -r ALG HASH <<<"${CERANA_INITRD_HASH}"
+    type "${ALG}sum" || return 2                                # don't know how to verify this checksum
+    "${ALG}sum" -c <<<"${HASH}  ${DESTINATION}/initrd" || return 3 # checksum failed
+}
+
+link_platform() {
+    rm -f /data/platform/current \
+        && ln -s "${DESTINATION#/data/platform/}" /data/platform/current
+}
+
+fetch_platform() {
+    SERVER=${CERANA_BOOT_SERVER%/} # don't depend on a trailing slash
+    mkdir -p "${DESTINATION}"
+    until curl -o "${DESTINATION}/bzImage" "${SERVER}/kernel"; do
+        sleep 1
+    done
+    curl -o "${DESTINATION}/initrd" "${SERVER}/initrd" || exit 1
+}
+
+if [[ -n "${CERANA_BOOT_SERVER}" ]]; then
+    # We were told where to get boot media
+    if [[ -n "${CERANA_INITRD_HASH}" ]]; then
+        # We know the checksum of the initrd we booted with too
+        verify_existing && link_platform && exit 0 # already got it!
+        fetch_platform
+        verify_existing \
+            && link_platform
+        exit $?
+    else
+        # If we didn't get a hash to use, use a default destination
+        # and just trust curl
+        DESTINATION=/data/platform/download
+        fetch_platform
+        link_platform
+        exit $?
+    fi
+elif [[ -L /dev/disk/by-label/CERANA ]]; then
     # The CD/USB is in the drive
+    DESTINATION=/data/platform/bootcd
     mkdir -p /mnt
     mount /dev/disk/by-label/CERANA /mnt
-    mkdir -p /data/platform/bootcd
-    rsync -a /mnt/ /data/platform/bootcd/
+    mkdir -p "${DESTINATION}"
+    rsync -a /mnt/ "${DESTINATION}/" \
+        && link_platform
+    ret=$?
     umount /mnt
-    rm -f /data/platform/current
-    ln -s bootcd /data/platform/current
-    # No physical media, most likely PXE booted
-    # FIXME https://github.com/cerana/cerana/issues/209
-    # Check to see if we already have latest media on disk
-    # If not, download it and update /data/platform/current symlink
+    exit ${ret}
+else
+    # No boot server provided, no boot media provided.
+    # Exit based on existence of media in the pool already
+    [[ -f /data/platform/current/bzImage ]] \
+        && [[ -f /data/platform/current/initrd ]]
+    exit $?
 fi

--- a/boot/scripts/parse-cmdline.sh
+++ b/boot/scripts/parse-cmdline.sh
@@ -37,6 +37,12 @@ function parse_boot_args() {
             $CERANA_PREFIX.mgmt_gw)
                 echo "CERANA_MGMT_GW=$v" >>$CERANA_BOOTCFG
                 ;;
+            $CERANA_PREFIX.initrd_hash)
+                echo "CERANA_INITRD_HASH=$v" >>$CERANA_BOOTCFG
+                ;;
+            $CERANA_PREFIX.boot_server)
+                echo "CERANA_BOOT_SERVER=$v" >>$CERANA_BOOTCFG
+                ;;
         esac
     done
 }
@@ -44,7 +50,7 @@ function parse_boot_args() {
 #if manually invoked with argument "test" do a quick sanity check to stdout
 if [[ "test" == "$1" ]]; then
     CERANA_BOOTCFG=/dev/stdout
-    CMDLINE="cerana.zfs_config=auto cerana.cluster_ips=10.2.3.4,10.2.3.5 cerana.cluster_bootstrap cerana.rescue cerana.mgmt_mac=00:00:00:00 cerana.mgmt_ip=10.2.3.6/24 cerana.mgmt_gw=10.2.3.1"
+    CMDLINE="cerana.zfs_config=auto cerana.cluster_ips=172.16.10.4,172.16.10.5 cerana.cluster_bootstrap cerana.rescue cerana.mgmt_mac=00:00:00:00 cerana.mgmt_ip=172.16.10.6/24 cerana.mgmt_gw=172.16.10.1 cerana.initrd_hash=sha256-748c35c5de02f473339867aa5fae1ab8d7893be3798041d03fade7c67896541b cerana.boot_server=http://172.16.10.4/"
 fi
 
 parse_boot_args


### PR DESCRIPTION
#### Description:

To be demo-ready we need some way of getting the platform image onto the PXE booted nodes.
This works for now.
Resolves #209

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/288)

<!-- Reviewable:end -->
