### PR TITLE
Filter out _CERANA_ prefix env vars during service creation

### DIFF
--- a/providers/service/create.go
+++ b/providers/service/create.go
@@ -46,6 +46,10 @@ func (p *Provider) Create(req *acomm.Request) (interface{}, *url.URL, error) {
 	}
 	// TODO: Add User= and Group= if not part of daisy
 	for key, val := range args.Env {
+		// do not allow custom overrides of the internal cerana env variables
+		if strings.HasPrefix(key, "_CERANA_") {
+			continue
+		}
 		unitOptions = append(unitOptions, &unit.UnitOption{
 			Section: "Service",
 			Name:    "Environment",

--- a/providers/service/create_test.go
+++ b/providers/service/create_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cerana/cerana/acomm"
 	"github.com/cerana/cerana/providers/service"
@@ -24,6 +25,7 @@ func (s *Provider) TestCreate() {
 		{uuid.New(), 219, "working service", []string{}, map[string]string{"foo": "bar"}, "missing arg: exec"},
 		{uuid.New(), 219, "working service", []string{"foo", "bar"}, map[string]string{}, ""},
 		{uuid.New(), 219, "working service", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, ""},
+		{uuid.New(), 219, "working service", []string{"foo", "bar"}, map[string]string{"_CERANA_foo": "bar"}, ""},
 	}
 
 	for _, test := range tests {
@@ -59,7 +61,14 @@ func (s *Provider) TestCreate() {
 			s.Equal(test.bundleID, getResult.Service.BundleID, desc)
 			s.Equal(test.description, getResult.Service.Description, desc)
 			s.Equal(test.exec, getResult.Service.Exec, desc)
-			s.Equal(test.env, getResult.Service.Env, desc)
+			for key, val := range test.env {
+				if strings.HasPrefix(key, "_CERANA_") {
+					_, ok := getResult.Service.Env[key]
+					s.False(ok, desc)
+				} else {
+					s.Equal(val, getResult.Service.Env[key], desc)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Description:

To prevent users from messing with cerana env vars, strip out all `_CERANA_` prefixed vars when creating a new service.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #291

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/300)

<!-- Reviewable:end -->
