### PR TITLE
Add dataset clone/rollback as service ExecStartPre

### DIFF
--- a/cmd/service-provider/main.go
+++ b/cmd/service-provider/main.go
@@ -13,13 +13,15 @@ import (
 func main() {
 	log.SetFormatter(&logx.JSONFormatter{})
 
-	config := provider.NewConfig(nil, nil)
+	config := service.NewConfig(nil, nil)
+	flag.StringP("rollback_clone_cmd", "r", "/run/current-system/sw/bin/rollback_clone", "full path to dataset clone/rollback tool")
+	flag.StringP("dataset_clone_dir", "d", "data/running-clones", "destination for dataset clones used by running services")
 	flag.Parse()
 
 	dieOnError(config.LoadConfig())
 	dieOnError(config.SetupLogging())
 
-	server, err := provider.NewServer(config)
+	server, err := provider.NewServer(config.Config)
 	dieOnError(err)
 	s := service.New(config, server.Tracker())
 	s.RegisterTasks(server)

--- a/providers/service/README.md
+++ b/providers/service/README.md
@@ -6,12 +6,71 @@
 
 ## Usage
 
+#### type Config
+
+```go
+type Config struct {
+	*provider.Config
+}
+```
+
+Config holds all configuration for the provider.
+
+#### func  NewConfig
+
+```go
+func NewConfig(flagSet *pflag.FlagSet, v *viper.Viper) *Config
+```
+NewConfig creates a new instance of Config.
+
+#### func (*Config) DatasetCloneBin
+
+```go
+func (c *Config) DatasetCloneBin() string
+```
+DatasetCloneBin returns the full path of the binary to clone/rollback datasets
+for services.
+
+#### func (*Config) DatasetClonePath
+
+```go
+func (c *Config) DatasetClonePath() string
+```
+DatasetClonePath returns the zfs path in which to clone datasets.
+
+#### func (*Config) LoadConfig
+
+```go
+func (c *Config) LoadConfig() error
+```
+LoadConfig loads and validates the config data.
+
+#### func (*Config) Validate
+
+```go
+func (c *Config) Validate() error
+```
+Validate returns whether the config is valid, containing necessary values.
+
+#### type ConfigData
+
+```go
+type ConfigData struct {
+	provider.ConfigData
+	DatasetCloneBin  string `json:"dataset_clone_bin"`
+	DatasetClonePath string `json:"dataset_clone_path"`
+}
+```
+
+ConfigData defines the structure of the config data (e.g. in the config file)
+
 #### type CreateArgs
 
 ```go
 type CreateArgs struct {
 	ID          string            `json:"id"`
 	BundleID    uint64            `json:"bundleID"`
+	Dataset     string            `json:"dataset"`
 	Description string            `json:"description"`
 	Exec        []string          `json:"exec"`
 	Env         map[string]string `json:"env"`
@@ -146,7 +205,7 @@ Provider is a provider of service management functionality.
 #### func  New
 
 ```go
-func New(config *provider.Config, tracker *acomm.Tracker) *Provider
+func New(config *Config, tracker *acomm.Tracker) *Provider
 ```
 New creates a new instance of Provider.
 

--- a/providers/service/config.go
+++ b/providers/service/config.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/cerana/cerana/provider"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// Config holds all configuration for the provider.
+type Config struct {
+	*provider.Config
+}
+
+// ConfigData defines the structure of the config data (e.g. in the config file)
+type ConfigData struct {
+	provider.ConfigData
+	RollbackCloneCmd string `json:"rollback_clone_cmd"`
+	DatasetCloneDir  string `json:"dataset_clone_dir"`
+}
+
+// RollbackCloneCmd returns the full path of the clone/rollback script datasets
+// for services.
+func (c *Config) RollbackCloneCmd() string {
+	var dcb string
+	_ = c.UnmarshalKey("rollback_clone_cmd", &dcb)
+	// Checked at validation time
+	return dcb
+}
+
+// DatasetCloneDir returns the zfs path in which to clone datasets.
+func (c *Config) DatasetCloneDir() string {
+	var dcp string
+	_ = c.UnmarshalKey("dataset_clone_dir", &dcp)
+	// Checked at validation time
+	return dcp
+}
+
+// LoadConfig loads and validates the config data.
+func (c *Config) LoadConfig() error {
+	if err := c.Config.LoadConfig(); err != nil {
+		return err
+	}
+
+	return c.Validate()
+}
+
+// NewConfig creates a new instance of Config.
+func NewConfig(flagSet *pflag.FlagSet, v *viper.Viper) *Config {
+	return &Config{provider.NewConfig(flagSet, v)}
+}
+
+// Validate returns whether the config is valid, containing necessary values.
+func (c *Config) Validate() error {
+	if err := c.Config.Validate(); err != nil {
+		return err
+	}
+
+	if c.RollbackCloneCmd() == "" {
+		return errors.New("missing rollback_clone_cmd")
+	}
+
+	if c.DatasetCloneDir() == "" {
+		return errors.New("missing dataset_clone_dir")
+	}
+
+	return nil
+}

--- a/providers/service/create.go
+++ b/providers/service/create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/cerana/cerana/acomm"
@@ -15,6 +16,7 @@ import (
 type CreateArgs struct {
 	ID          string            `json:"id"`
 	BundleID    uint64            `json:"bundleID"`
+	Dataset     string            `json:"dataset"`
 	Description string            `json:"description"`
 	Exec        []string          `json:"exec"`
 	Env         map[string]string `json:"env"`
@@ -35,14 +37,22 @@ func (p *Provider) Create(req *acomm.Request) (interface{}, *url.URL, error) {
 	if len(args.Exec) == 0 {
 		return nil, nil, errors.New("missing arg: exec")
 	}
+	if args.Dataset == "" {
+		return nil, nil, errors.New("missing arg: dataset")
+	}
 
 	name := serviceName(args.BundleID, args.ID)
+	datasetCloneName := filepath.Join(p.config.DatasetCloneDir(), name)
 	unitOptions := []*unit.UnitOption{
 		{Section: "Unit", Name: "Description", Value: args.Description},
 		// TODO: Does exec get prepended with daisy?
 		{Section: "Service", Name: "ExecStart", Value: strings.Join(args.Exec, " ")},
 		{Section: "Service", Name: "Type", Value: "forking"},
 		{Section: "Install", Name: "WantedBy", Value: "cerana.Target"},
+
+		{Section: "Service", Name: "ExecStartPre", Value: p.config.RollbackCloneCmd()},
+		{Section: "Environment", Name: "_CERANA_CLONE_SOURCE", Value: args.Dataset},
+		{Section: "Environment", Name: "_CERANA_CLONE_DESTINATION", Value: datasetCloneName},
 	}
 	// TODO: Add User= and Group= if not part of daisy
 	for key, val := range args.Env {

--- a/providers/service/create_test.go
+++ b/providers/service/create_test.go
@@ -10,28 +10,32 @@ import (
 )
 
 func (s *Provider) TestCreate() {
+	ds := uuid.New()
 	tests := []struct {
 		id          string
 		bundleID    uint64
+		dataset     string
 		description string
 		exec        []string
 		env         map[string]string
 		err         string
 	}{
-		{"", 219, "working service", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, "missing arg: id"},
-		{uuid.New(), 0, "working service", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, "missing arg: bundleID"},
-		{uuid.New(), 219, "", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, ""},
-		{uuid.New(), 219, "working service", nil, map[string]string{"foo": "bar"}, "missing arg: exec"},
-		{uuid.New(), 219, "working service", []string{}, map[string]string{"foo": "bar"}, "missing arg: exec"},
-		{uuid.New(), 219, "working service", []string{"foo", "bar"}, map[string]string{}, ""},
-		{uuid.New(), 219, "working service", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, ""},
-		{uuid.New(), 219, "working service", []string{"foo", "bar"}, map[string]string{"_CERANA_foo": "bar"}, ""},
+		{"", 219, ds, "working service", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, "missing arg: id"},
+		{uuid.New(), 0, ds, "working service", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, "missing arg: bundleID"},
+		{uuid.New(), 219, ds, "", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, ""},
+		{uuid.New(), 219, ds, "working service", nil, map[string]string{"foo": "bar"}, "missing arg: exec"},
+		{uuid.New(), 219, ds, "working service", []string{}, map[string]string{"foo": "bar"}, "missing arg: exec"},
+		{uuid.New(), 219, "", "working service", []string{"foo", "bar"}, map[string]string{}, "missing arg: dataset"},
+		{uuid.New(), 219, ds, "working service", []string{"foo", "bar"}, map[string]string{}, ""},
+		{uuid.New(), 219, ds, "working service", []string{"foo", "bar"}, map[string]string{"foo": "bar"}, ""},
+		{uuid.New(), 219, ds, "working service", []string{"foo", "bar"}, map[string]string{"_CERANA_foo": "bar"}, ""},
 	}
 
 	for _, test := range tests {
 		args := &service.CreateArgs{
 			ID:          test.id,
 			BundleID:    test.bundleID,
+			Dataset:     test.dataset,
 			Description: test.description,
 			Exec:        test.exec,
 			Env:         test.env,

--- a/providers/service/mock.go
+++ b/providers/service/mock.go
@@ -53,6 +53,9 @@ func (m *Mock) Create(req *acomm.Request) (interface{}, *url.URL, error) {
 	if len(args.Exec) == 0 {
 		return nil, nil, errors.New("missing arg: exec")
 	}
+	if args.Dataset == "" {
+		return nil, nil, errors.New("missing arg: dataset")
+	}
 
 	if _, ok := m.Data.Services[args.BundleID]; !ok {
 		m.Data.Services[args.BundleID] = make(map[string]Service)

--- a/providers/service/service.go
+++ b/providers/service/service.go
@@ -7,12 +7,12 @@ import (
 
 // Provider is a provider of service management functionality.
 type Provider struct {
-	config  *provider.Config
+	config  *Config
 	tracker *acomm.Tracker
 }
 
 // New creates a new instance of Provider.
-func New(config *provider.Config, tracker *acomm.Tracker) *Provider {
+func New(config *Config, tracker *acomm.Tracker) *Provider {
 	return &Provider{
 		config:  config,
 		tracker: tracker,

--- a/providers/service/service_test.go
+++ b/providers/service/service_test.go
@@ -19,7 +19,7 @@ import (
 type Provider struct {
 	suite.Suite
 	coordinator  *test.Coordinator
-	config       *provider.Config
+	config       *service.Config
 	provider     *service.Provider
 	tracker      *acomm.Tracker
 	flagset      *pflag.FlagSet
@@ -41,7 +41,9 @@ func (s *Provider) SetupSuite() {
 
 	v := s.coordinator.NewProviderViper()
 	flagset := pflag.NewFlagSet("service", pflag.PanicOnError)
-	config := provider.NewConfig(flagset, v)
+	v.Set("rollback_clone_cmd", "foo/bar")
+	v.Set("dataset_clone_dir", "tmp")
+	config := service.NewConfig(flagset, v)
 	s.Require().NoError(flagset.Parse([]string{}))
 	s.Require().NoError(config.LoadConfig())
 	s.Require().NoError(config.SetupLogging())
@@ -71,7 +73,7 @@ func (s *Provider) TearDownSuite() {
 }
 
 func (s *Provider) TestRegisterTasks() {
-	server, err := provider.NewServer(s.config)
+	server, err := provider.NewServer(s.config.Config)
 	s.Require().NoError(err)
 
 	s.provider.RegisterTasks(server)


### PR DESCRIPTION
#### Description:

Add the dataset clone/rollback to the service file's `ExecStartPre`. The clone/rollback tool and clone path are configurable, with ceranaos defaults.
#### Issues affected:
#284

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/303)

<!-- Reviewable:end -->
