### PR TITLE
kv provider lazy init

### DIFF
--- a/pkg/kv/README.md
+++ b/pkg/kv/README.md
@@ -2,7 +2,7 @@
 
 [![kv](https://godoc.org/github.com/cerana/cerana/pkg/kv?status.svg)](https://godoc.org/github.com/cerana/cerana/pkg/kv)
 
-Package kv abstracts a distributed/clusted kv store for use with lochness kv
+Package kv abstracts a distributed/clustered kv store for use with cerana kv
 does not aim to be a full-featured generic kv abstraction, but can be useful
 anyway. Only implementors imported by users will be available at runtime. See
 documentation of KV for handled operations.

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -1,4 +1,4 @@
-// Package kv abstracts a distributed/clusted kv store for use with lochness
+// Package kv abstracts a distributed/clustered kv store for use with cerana
 // kv does not aim to be a full-featured generic kv abstraction, but can be useful anyway.
 // Only implementors imported by users will be available at runtime.
 // See documentation of KV for handled operations.

--- a/providers/kv/basic.go
+++ b/providers/kv/basic.go
@@ -35,6 +35,9 @@ func (k *KV) delete(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: key")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	return nil, nil, k.kv.Delete(args.Key, args.Recursive)
 }
 
@@ -48,6 +51,9 @@ func (k *KV) get(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: key")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	kvp, err := k.kv.Get(args.Key)
 	if err != nil {
 		return nil, nil, err
@@ -66,6 +72,9 @@ func (k *KV) getAll(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: key")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	kvps, err := k.kv.GetAll(args.Key)
 	if err != nil {
 		return nil, nil, err
@@ -84,6 +93,9 @@ func (k *KV) keys(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: key")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	keys, err := k.kv.Keys(args.Key)
 	if err != nil {
 		return nil, nil, err
@@ -105,5 +117,8 @@ func (k *KV) set(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: data")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	return nil, nil, k.kv.Set(args.Key, args.Data)
 }

--- a/providers/kv/cas.go
+++ b/providers/kv/cas.go
@@ -36,6 +36,9 @@ func (k *KV) remove(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: key")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	return nil, nil, k.kv.Remove(args.Key, args.Index)
 }
 
@@ -57,6 +60,9 @@ func (k *KV) update(req *acomm.Request) (interface{}, *url.URL, error) {
 		Index: args.Index,
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	index, err := k.kv.Update(args.Key, value)
 	if err != nil {
 		return nil, nil, err

--- a/providers/kv/ekey.go
+++ b/providers/kv/ekey.go
@@ -38,6 +38,9 @@ func (k *KV) eset(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: ttl")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	eKey := eKeys.Get(args.Key)
 	if eKey == nil || eKey.Renew() != nil {
 		eKey, err = k.kv.EphemeralKey(args.Key, args.TTL)

--- a/providers/kv/lock.go
+++ b/providers/kv/lock.go
@@ -30,6 +30,9 @@ func (k *KV) lock(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: ttl")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	lock, err := k.kv.Lock(args.Key, args.TTL)
 	if err != nil {
 		return nil, nil, err

--- a/providers/kv/watch.go
+++ b/providers/kv/watch.go
@@ -73,6 +73,9 @@ func (k *KV) watch(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, errors.New("missing arg: prefix")
 	}
 
+	if k.kvDown() {
+		return nil, nil, errorKVDown
+	}
 	stop := make(chan struct{})
 	events, errs, err := k.kv.Watch(args.Prefix, args.Index, stop)
 	if err != nil {


### PR DESCRIPTION
#### Description:

Allow kv-provider to service requests before connection to kv has been established. Once the connection has been established any kv failures were already being returned while kv-provider stayed up.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #NONE :(

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/313)

<!-- Reviewable:end -->
