### PR TITLE
Kv mock fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - make lint-required
 
 script:
-  - make test -j $(nproc)
+  - make test
 
 after_success:
   - make lint-optional

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: $(testOutputs)
 # Add /dev/zfs device for zfs to work.
 .SECONDEXPANSION:
 $(testOutputs): %/test.out: $$(call testBinFromDir,%)
-	flock /dev/stdout -c 'echo "RUN   $<"'
+	echo "RUN   $<"
 	./run-test.sh $<
 
 # Build a package's test binaries. Done outside the container so it can be used
@@ -60,7 +60,7 @@ $(testOutputs): %/test.out: $$(call testBinFromDir,%)
 .SECONDARY: $(testBins)
 $(testBins): %.test: FORCE
 	echo BUILD $@
-	cd $(dir $@) && flock -s /dev/stdout go test -c -i
+	cd $(dir $@) && go test -c -i
 
 FORCE:
 

--- a/internal/tests/common/ct.go
+++ b/internal/tests/common/ct.go
@@ -118,6 +118,10 @@ func (s *Suite) SetupSuite() {
 		if err == nil {
 			break
 		}
+		err = s.KV.Ping()
+		if err == nil {
+			break
+		}
 		time.Sleep(500 * time.Millisecond) // Wait for test kv to be ready
 	}
 	if s.KV == nil {

--- a/providers/kv/mock.go
+++ b/providers/kv/mock.go
@@ -56,16 +56,28 @@ func (m *Mock) Stop() {
 
 // Get will perform a Get operation directly on the kv store.
 func (m *Mock) Get(key string) (Value, error) {
+	if m.kvDown() {
+		return Value{}, errorKVDown
+	}
+
 	kvV, err := m.KV.kv.Get(key)
 	return Value(kvV), err
 }
 
 // Set will perform a Set operation directly on the kv store.
 func (m *Mock) Set(key, value string) error {
+	if m.kvDown() {
+		return errorKVDown
+	}
+
 	return m.KV.kv.Set(key, value)
 }
 
 // Clean will perform a recursive Delete operation directly on the kv store.
 func (m *Mock) Clean(prefix string) error {
+	if m.kvDown() {
+		return nil
+	}
+
 	return m.KV.kv.Delete(prefix, true)
 }

--- a/run-test.sh
+++ b/run-test.sh
@@ -8,7 +8,7 @@ set -e
 dir=$(dirname $1)
 name=$(basename $1)
 out="$dir/test.out"
-exec 2> $out
+exec 2> >(tee $out)
 
 which consul &>/dev/null
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -34,5 +34,6 @@ docker exec $cid sh -c "cd /mistify/$dir; ./$name -test.v" >&2 || ret=$?;
 
 docker kill  $cid > /dev/null || :
 docker rm -v $cid > /dev/null || :
-flock /dev/stdout -c "echo '### TEST  $name'; cat $out"
+echo '### TEST  $name'
+cat $out
 exit $ret


### PR DESCRIPTION
#### Description:

kv mock was causing all sorts of problems on travis. dhcp.TestConfig would panic due to Mock and also cause the container to hang, which causes the test to hang. Now mock no longer panics.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/314)

<!-- Reviewable:end -->
