### PR TITLE
cmd/coordinator-cli: do not convert json numbers to float

### DIFF
--- a/cmd/coordinator-cli/main.go
+++ b/cmd/coordinator-cli/main.go
@@ -123,6 +123,7 @@ func parseTaskArgs(taskArgs []string) (map[string]interface{}, error) {
 func parseJSONArgs() (map[string]interface{}, error) {
 	var out map[string]interface{}
 	decoder := json.NewDecoder(os.Stdin)
+	decoder.UseNumber()
 	if err := decoder.Decode(&out); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Description:

encoding/json treats json numbers as float when the target is interface{},
when coordinator-cli hands that to acomm it gets encoded as a float which can
not be parsed as a time.Duration (int64).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/325)

<!-- Reviewable:end -->
