### PR TITLE
Set dhcp config task

### DIFF
--- a/cmd/dhcp-provider/main.go
+++ b/cmd/dhcp-provider/main.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/cerana/cerana/acomm"
@@ -55,24 +54,6 @@ func getDHCPConfig(tracker *acomm.Tracker, coordinator *url.URL) *clusterconf.DH
 	return dconf
 }
 
-func setDHCPConfig(tracker *acomm.Tracker, coordinator *url.URL, config *dhcp.Config) {
-	dconf := clusterconf.DHCPConfig{}
-	err := comm(tracker, coordinator, "get-dhcp", nil, &dconf)
-	if err == nil {
-		logrus.Warn("dhcp configuration exists, not overriding it")
-		return
-	}
-
-	dconf = clusterconf.DHCPConfig{
-		DNS:      config.DNSServers(),
-		Duration: config.LeaseDuration(),
-		Gateway:  config.Gateway(),
-		Net:      *config.Network(),
-	}
-	err = comm(tracker, coordinator, "set-dhcp", dconf, nil)
-	logrusx.DieOnError(err, "set dhcp configuration")
-}
-
 func joinDNS(dns []net.IP) string {
 	strs := make([]string, len(dns))
 	for i := range dns {
@@ -86,31 +67,22 @@ func main() {
 
 	v := viper.New()
 	f := pflag.NewFlagSet("dhcp-provider", pflag.ExitOnError)
-	f.String("dns-servers", "", "[optional] comma separated list of dns servers ")
-	f.IP("gateway", nil, "[optional] default gateway")
-	f.Duration("lease-duration", 24*time.Hour, "default lease duration")
-	f.IPNet("network", defaultNetwork(), "network to manage dhcp addresses on")
 
 	config := dhcp.NewConfig(f, v)
 	logrusx.DieOnError(f.Parse(os.Args), "parse arguments")
 	logrusx.DieOnError(config.LoadConfig(), "load configuration")
 	logrusx.DieOnError(config.SetupLogging(), "setup logging")
 
-	set := v.IsSet("dns-servers") || v.IsSet("gateway") || v.IsSet("lease-duration") || v.IsSet("network")
-
 	server, err := provider.NewServer(config.Config)
 	logrusx.DieOnError(err, "create provider")
 	logrusx.DieOnError(server.Tracker().Start(), "start tracker")
 
-	if set == true {
-		setDHCPConfig(server.Tracker(), config.CoordinatorURL(), config)
-	}
 	storedConfig := getDHCPConfig(server.Tracker(), config.CoordinatorURL())
 
-	v.Set("dns-servers", joinDNS(storedConfig.DNS))
+	v.Set("dns-servers", storedConfig.DNS)
 	v.Set("gateway", storedConfig.Gateway)
 	v.Set("lease-duration", storedConfig.Duration)
-	v.Set("network", storedConfig.Net.String())
+	v.Set("network", storedConfig.Net)
 
 	d, err := dhcp.New(config, server.Tracker())
 	logrusx.DieOnError(err, "create dhcp server")

--- a/cmd/dhcp-provider/main.go
+++ b/cmd/dhcp-provider/main.go
@@ -49,7 +49,7 @@ func comm(tracker *acomm.Tracker, coordinator *url.URL, task string, args interf
 
 func getDHCPConfig(tracker *acomm.Tracker, coordinator *url.URL) *clusterconf.DHCPConfig {
 	dconf := &clusterconf.DHCPConfig{}
-	err := comm(tracker, coordinator, "get-dhcp", nil, dconf)
+	err := comm(tracker, coordinator, "get-dhcp-config", nil, dconf)
 	logrusx.DieOnError(err, "get dhcp configuration")
 	return dconf
 }

--- a/providers/clusterconf/clusterconf.go
+++ b/providers/clusterconf/clusterconf.go
@@ -57,8 +57,8 @@ func (c *ClusterConf) RegisterTasks(server *provider.Server) {
 	server.RegisterTask("update-service", c.UpdateService)
 	server.RegisterTask("delete-service", c.DeleteService)
 
-	server.RegisterTask("get-dhcp", c.GetDHCP)
-	server.RegisterTask("set-dhcp", c.SetDHCP)
+	server.RegisterTask("get-dhcp-config", c.GetDHCP)
+	server.RegisterTask("set-dhcp-config", c.SetDHCP)
 }
 
 func (c *ClusterConf) kvReq(task string, args map[string]interface{}) (*acomm.Response, error) {

--- a/providers/clusterconf/dhcp.go
+++ b/providers/clusterconf/dhcp.go
@@ -84,12 +84,9 @@ func (c *ClusterConf) SetDHCP(req *acomm.Request) (interface{}, *url.URL, error)
 		return nil, nil, err
 	}
 
-	index := uint64(0)
-	value, err := c.kvGet(dhcpPrefix)
-	if err == nil {
-		index = value.Index
+	_, err := c.kvUpdate(dhcpPrefix, conf, 0)
+	if err != nil {
+		err = errors.New("dhcp configuration can not be altered")
 	}
-
-	_, err = c.kvUpdate(dhcpPrefix, conf, index)
 	return nil, nil, err
 }

--- a/providers/clusterconf/dhcp.go
+++ b/providers/clusterconf/dhcp.go
@@ -50,6 +50,7 @@ func (c *DHCPConfig) Validate() error {
 func (c *ClusterConf) GetDHCP(*acomm.Request) (interface{}, *url.URL, error) {
 	value, err := c.kvGet(dhcpPrefix)
 	if err != nil {
+		return nil, nil, err
 	}
 
 	config := DHCPConfig{}

--- a/providers/clusterconf/dhcp.go
+++ b/providers/clusterconf/dhcp.go
@@ -53,17 +53,18 @@ func (c *ClusterConf) GetDHCP(*acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, err
 	}
 
-	config := DHCPConfig{}
-	if err := json.Unmarshal(value.Data, &config); err != nil {
+	conf := DHCPConfig{}
+	if err := json.Unmarshal(value.Data, &conf); err != nil {
 		return nil, nil, errors.Wrapv(err, map[string]interface{}{"json": string(value.Data)})
 	}
-	return config, nil, nil
+
+	return conf, nil, nil
 }
 
 // SetDHCP updates the cluster DHCP settings.
 func (c *ClusterConf) SetDHCP(req *acomm.Request) (interface{}, *url.URL, error) {
-	conf := &DHCPConfig{}
-	if err := req.UnmarshalArgs(conf); err != nil {
+	conf := DHCPConfig{}
+	if err := req.UnmarshalArgs(&conf); err != nil {
 		return nil, nil, err
 	}
 

--- a/providers/clusterconf/dhcp_test.go
+++ b/providers/clusterconf/dhcp_test.go
@@ -69,19 +69,6 @@ func (s *clusterConf) TestGetDHCP() {
 }
 
 func (s *clusterConf) TestSetDHCP() {
-	s.setupDHCP(clusterconf.DHCPConfig{
-		DNS: []net.IP{
-			net.IPv4(10, 10, 1, byte(rand.Intn(255))),
-			net.IPv4(10, 10, 2, byte(rand.Intn(255))),
-		},
-		Duration: 5*time.Hour + time.Hour*time.Duration(rand.Intn(11)+1),
-		Gateway:  net.IPv4(10, 10, 10, byte(rand.Intn(255))),
-		Net: net.IPNet{
-			IP:   net.IPv4(10, 10, 10, 0),
-			Mask: net.IPMask{255, 255, 255, 0},
-		},
-	})
-
 	tests := []struct {
 		desc string
 		err  string

--- a/providers/clusterconf/dhcp_test.go
+++ b/providers/clusterconf/dhcp_test.go
@@ -83,6 +83,20 @@ func (s *clusterConf) TestSetDHCP() {
 				Net:      "10.100.10.0",
 			},
 		},
+		{desc: "junk network",
+			err: "invalid CIDR address: 256.256.256.256/32",
+			conf: clusterconf.DHCPConfig{
+				Duration: "1h",
+				Net:      "256.256.256.256/32",
+			},
+		},
+		{desc: "junk netmask",
+			err: "invalid CIDR address: 10.100.10.0/33",
+			conf: clusterconf.DHCPConfig{
+				Duration: "1h",
+				Net:      "10.100.10.0/33",
+			},
+		},
 		{desc: "unreachable gateway",
 			err: "gateway is unreachable",
 			conf: clusterconf.DHCPConfig{

--- a/providers/clusterconf/dhcp_test.go
+++ b/providers/clusterconf/dhcp_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"net"
-	"time"
 
 	"github.com/cerana/cerana/acomm"
 	"github.com/cerana/cerana/providers/clusterconf"
@@ -17,35 +15,8 @@ func (s *clusterConf) setupDHCP(config clusterconf.DHCPConfig) {
 	s.Require().NoError(s.kv.Set("dhcp", string(buf)))
 }
 
-type DHCPConfigStrs struct {
-	DNS      []string
-	Duration string
-	Gateway  string
-	Net      string
-}
-
-func (d DHCPConfigStrs) toConfig() clusterconf.DHCPConfig {
-	c := clusterconf.DHCPConfig{
-		DNS:     make([]net.IP, len(d.DNS)),
-		Gateway: net.ParseIP(d.Gateway),
-	}
-
-	for i, dns := range d.DNS {
-		c.DNS[i] = net.ParseIP(dns)
-	}
-
-	c.Duration, _ = time.ParseDuration(d.Duration)
-	_, subnet, _ := net.ParseCIDR(d.Net)
-	if subnet != nil {
-		c.Net.IP = subnet.IP.To16()
-		c.Net.Mask = subnet.Mask
-	}
-
-	return c
-}
-
 func (s *clusterConf) TestGetDHCP() {
-	sconf := DHCPConfigStrs{
+	conf := clusterconf.DHCPConfig{
 		DNS: []string{
 			fmt.Sprintf("10.10.1.%d", rand.Intn(255)),
 			fmt.Sprintf("10.10.2.%d", rand.Intn(255)),
@@ -54,7 +25,6 @@ func (s *clusterConf) TestGetDHCP() {
 		Gateway:  fmt.Sprintf("10.10.10.%d", rand.Intn(255)),
 		Net:      "10.10.10.0/24",
 	}
-	conf := sconf.toConfig()
 
 	_, _, err := s.clusterConf.GetDHCP(nil)
 	s.Error(err, "expected no dhcp settings")
@@ -72,57 +42,57 @@ func (s *clusterConf) TestSetDHCP() {
 	tests := []struct {
 		desc string
 		err  string
-		conf DHCPConfigStrs
+		conf clusterconf.DHCPConfig
 	}{
 		{desc: "duration too short",
 			err: "duration is invalid",
-			conf: DHCPConfigStrs{
+			conf: clusterconf.DHCPConfig{
 				Duration: "30m",
 			},
 		},
 		{desc: "duration too long",
 			err: "duration is invalid",
-			conf: DHCPConfigStrs{
+			conf: clusterconf.DHCPConfig{
 				Duration: "25h",
 			},
 		},
 		{desc: "missing network",
-			err: "net.IP is required",
-			conf: DHCPConfigStrs{
+			err: "invalid CIDR address: ",
+			conf: clusterconf.DHCPConfig{
 				Duration: "1h",
 			},
 		},
 		{desc: "IPv6",
-			err: "net.IP must be IPv4",
-			conf: DHCPConfigStrs{
+			err: "net.ip must be IPv4",
+			conf: clusterconf.DHCPConfig{
 				Duration: "1h",
 				Net:      "::1/128",
 			},
 		},
 		{desc: "IPv4zero",
-			err: "net.IP must not be 0.0.0.0",
-			conf: DHCPConfigStrs{
+			err: "net.ip must not be 0.0.0.0",
+			conf: clusterconf.DHCPConfig{
 				Duration: "1h",
 				Net:      "0.0.0.0/0",
 			},
 		},
 		{desc: "missing netmask",
-			err: "net.IP is required",
-			conf: DHCPConfigStrs{
+			err: "invalid CIDR address: 10.100.10.0",
+			conf: clusterconf.DHCPConfig{
 				Duration: "1h",
 				Net:      "10.100.10.0",
 			},
 		},
 		{desc: "unreachable gateway",
 			err: "gateway is unreachable",
-			conf: DHCPConfigStrs{
+			conf: clusterconf.DHCPConfig{
 				Duration: "1h",
 				Gateway:  fmt.Sprintf("10.0.10.%d", rand.Intn(255)),
 				Net:      "10.100.10.0/24",
 			},
 		},
 		{desc: "good",
-			conf: DHCPConfigStrs{
+			conf: clusterconf.DHCPConfig{
 				DNS: []string{
 					fmt.Sprintf("10.100.1.%d", rand.Intn(255)),
 					fmt.Sprintf("10.100.2.%d", rand.Intn(255)),
@@ -137,7 +107,7 @@ func (s *clusterConf) TestSetDHCP() {
 	for _, t := range tests {
 		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task: "clusterconf-set-dhcp",
-			Args: t.conf.toConfig(),
+			Args: t.conf,
 		})
 		s.Require().NoError(err, t.desc)
 
@@ -157,6 +127,6 @@ func (s *clusterConf) TestSetDHCP() {
 		s.Nil(url)
 
 		got := resp.(clusterconf.DHCPConfig)
-		s.Equal(t.conf.toConfig(), got, t.desc)
+		s.Equal(t.conf, got, t.desc)
 	}
 }

--- a/providers/clusterconf/dhcp_test.go
+++ b/providers/clusterconf/dhcp_test.go
@@ -85,76 +85,64 @@ func (s *clusterConf) TestSetDHCP() {
 	tests := []struct {
 		desc string
 		err  string
-		conf clusterconf.DHCPConfig
+		conf DHCPConfigStrs
 	}{
 		{desc: "duration too short",
 			err: "duration is invalid",
-			conf: clusterconf.DHCPConfig{
-				Duration: 30 * time.Minute,
+			conf: DHCPConfigStrs{
+				Duration: "30m",
 			},
 		},
 		{desc: "duration too long",
 			err: "duration is invalid",
-			conf: clusterconf.DHCPConfig{
-				Duration: 25 * time.Hour,
+			conf: DHCPConfigStrs{
+				Duration: "25h",
 			},
 		},
 		{desc: "missing network",
 			err: "net.IP is required",
-			conf: clusterconf.DHCPConfig{
-				Duration: 1 * time.Hour,
+			conf: DHCPConfigStrs{
+				Duration: "1h",
 			},
 		},
 		{desc: "IPv6",
 			err: "net.IP must be IPv4",
-			conf: clusterconf.DHCPConfig{
-				Duration: 1 * time.Hour,
-				Net: net.IPNet{
-					IP: net.ParseIP("::1"),
-				},
+			conf: DHCPConfigStrs{
+				Duration: "1h",
+				Net:      "::1/128",
 			},
 		},
 		{desc: "IPv4zero",
 			err: "net.IP must not be 0.0.0.0",
-			conf: clusterconf.DHCPConfig{
-				Duration: 1 * time.Hour,
-				Net: net.IPNet{
-					IP: net.IPv4zero,
-				},
+			conf: DHCPConfigStrs{
+				Duration: "1h",
+				Net:      "0.0.0.0/0",
 			},
 		},
 		{desc: "missing netmask",
-			err: "net.Mask is required",
-			conf: clusterconf.DHCPConfig{
-				Duration: 1 * time.Hour,
-				Net: net.IPNet{
-					IP: net.ParseIP("127.0.0.1"),
-				},
+			err: "net.IP is required",
+			conf: DHCPConfigStrs{
+				Duration: "1h",
+				Net:      "10.100.10.0",
 			},
 		},
 		{desc: "unreachable gateway",
 			err: "gateway is unreachable",
-			conf: clusterconf.DHCPConfig{
-				Duration: 1 * time.Hour,
-				Gateway:  net.IPv4(10, 0, 10, byte(rand.Intn(255))),
-				Net: net.IPNet{
-					IP:   net.IPv4(10, 100, 10, 0),
-					Mask: net.IPMask{255, 255, 255, 0},
-				},
+			conf: DHCPConfigStrs{
+				Duration: "1h",
+				Gateway:  fmt.Sprintf("10.0.10.%d", rand.Intn(255)),
+				Net:      "10.100.10.0/24",
 			},
 		},
 		{desc: "good",
-			conf: clusterconf.DHCPConfig{
-				DNS: []net.IP{
-					net.IPv4(10, 100, 1, byte(rand.Intn(255))),
-					net.IPv4(10, 100, 2, byte(rand.Intn(255))),
+			conf: DHCPConfigStrs{
+				DNS: []string{
+					fmt.Sprintf("10.100.1.%d", rand.Intn(255)),
+					fmt.Sprintf("10.100.2.%d", rand.Intn(255)),
 				},
-				Duration: 1 * time.Hour,
-				Gateway:  net.IPv4(10, 100, 10, byte(rand.Intn(255))),
-				Net: net.IPNet{
-					IP:   net.IPv4(10, 100, 10, 0),
-					Mask: net.IPMask{255, 255, 255, 0},
-				},
+				Duration: "1h",
+				Gateway:  fmt.Sprintf("10.100.10.%d", rand.Intn(255)),
+				Net:      "10.100.10.0/24",
 			},
 		},
 	}
@@ -162,7 +150,7 @@ func (s *clusterConf) TestSetDHCP() {
 	for _, t := range tests {
 		req, err := acomm.NewRequest(acomm.RequestOptions{
 			Task: "clusterconf-set-dhcp",
-			Args: t.conf,
+			Args: t.conf.toConfig(),
 		})
 		s.Require().NoError(err, t.desc)
 
@@ -182,6 +170,6 @@ func (s *clusterConf) TestSetDHCP() {
 		s.Nil(url)
 
 		got := resp.(clusterconf.DHCPConfig)
-		s.Equal(t.conf, got, t.desc)
+		s.Equal(t.conf.toConfig(), got, t.desc)
 	}
 }

--- a/providers/clusterconf/dhcp_test.go
+++ b/providers/clusterconf/dhcp_test.go
@@ -102,6 +102,18 @@ func (s *clusterConf) TestSetDHCP() {
 				Net:      "10.100.10.0/24",
 			},
 		},
+		{desc: "dhcp is set in stone",
+			err: "dhcp configuration can not be altered",
+			conf: clusterconf.DHCPConfig{
+				DNS: []string{
+					fmt.Sprintf("10.100.1.%d", rand.Intn(255)),
+					fmt.Sprintf("10.100.2.%d", rand.Intn(255)),
+				},
+				Duration: "2h",
+				Gateway:  fmt.Sprintf("10.100.10.%d", rand.Intn(255)),
+				Net:      "10.100.10.0/24",
+			},
+		},
 	}
 
 	for _, t := range tests {

--- a/providers/clusterconf/dhcp_test.go
+++ b/providers/clusterconf/dhcp_test.go
@@ -132,24 +132,24 @@ func (s *clusterConf) TestSetDHCP() {
 			Task: "clusterconf-set-dhcp",
 			Args: t.conf,
 		})
-		s.Require().NoError(err)
+		s.Require().NoError(err, t.desc)
 
 		resp, url, err := s.clusterConf.SetDHCP(req)
-		s.Nil(resp)
-		s.Nil(url)
+		s.Nil(resp, t.desc)
+		s.Nil(url, t.desc)
 		if !t.ok {
 			s.Contains(err.Error(), t.desc)
 			continue
 		}
-		if !s.NoError(err) {
+		if !s.NoError(err, t.desc) {
 			continue
 		}
 
 		resp, url, err = s.clusterConf.GetDHCP(nil)
-		s.Require().NoError(err)
+		s.Require().NoError(err, t.desc)
 		s.Nil(url)
 
 		got := resp.(clusterconf.DHCPConfig)
-		s.Equal(t.conf, got)
+		s.Equal(t.conf, got, t.desc)
 	}
 }

--- a/providers/clusterconf/dhcp_test.go
+++ b/providers/clusterconf/dhcp_test.go
@@ -2,6 +2,7 @@ package clusterconf_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"net"
 	"time"
@@ -44,18 +45,16 @@ func (d DHCPConfigStrs) toConfig() clusterconf.DHCPConfig {
 }
 
 func (s *clusterConf) TestGetDHCP() {
-	conf := clusterconf.DHCPConfig{
-		DNS: []net.IP{
-			net.IPv4(10, 10, 1, byte(rand.Intn(255))),
-			net.IPv4(10, 10, 2, byte(rand.Intn(255))),
+	sconf := DHCPConfigStrs{
+		DNS: []string{
+			fmt.Sprintf("10.10.1.%d", rand.Intn(255)),
+			fmt.Sprintf("10.10.2.%d", rand.Intn(255)),
 		},
-		Duration: 5*time.Hour + time.Hour*time.Duration(rand.Intn(11)+1),
-		Gateway:  net.IPv4(10, 10, 10, byte(rand.Intn(255))),
-		Net: net.IPNet{
-			IP:   net.IPv4(10, 10, 10, 0),
-			Mask: net.IPMask{255, 255, 255, 0},
-		},
+		Duration: fmt.Sprintf("%dh", 1+rand.Intn(24)),
+		Gateway:  fmt.Sprintf("10.10.10.%d", rand.Intn(255)),
+		Net:      "10.10.10.0/24",
 	}
+	conf := sconf.toConfig()
 
 	_, _, err := s.clusterConf.GetDHCP(nil)
 	s.Error(err, "expected no dhcp settings")


### PR DESCRIPTION
#### Description:

This pr changes the workflow of setting up the dhcp configuration for the management cluster. dhcp-provider is no longer tasked with setting up the configuration, it was not a good fit for it and it was mostly just a proxy to clusterconf anyway.

clusterconf was extended to only allow the network configuration to be set once. Both the get/set task args/response were changed to be the string forms of ips and network CIDR for ease of use. The string form is also saved to the kv.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/344)

<!-- Reviewable:end -->
