### PR TITLE
Update logrusx for use with pkg/errors

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -110,7 +110,7 @@ func Newf(format string, args ...interface{}) error {
 // Newv returns a new error with the callstack that formats as the given text
 // and associates the supplied data with the error.
 func Newv(msg string, values map[string]interface{}) error {
-	return Wrapv(New(msg), values)
+	return Wrapv(fromError(errors.New(msg)), values)
 }
 
 // Wrap wraps an error, creating a callstack if necessary and prefixing the
@@ -148,7 +148,7 @@ func Wrapv(err error, values map[string]interface{}, msg ...string) error {
 		return nil
 	}
 
-	eExt := Wrap(err, msg...).(*errorExt)
+	eExt := Wrap(fromError(err), msg...).(*errorExt)
 	for k, v := range values {
 		eExt.data[k] = v
 	}

--- a/pkg/logrusx/README.md
+++ b/pkg/logrusx/README.md
@@ -38,19 +38,6 @@ func SetLevel(logLevel string) error
 ```
 SetLevel parses and sets the log level
 
-#### type FieldError
-
-```go
-type FieldError struct {
-	Error   error
-	Message string
-	Stack   []string
-}
-```
-
-FieldError contains both the error struct and error message as explicit
-properties, including both when JSON marshaling.
-
 #### type JSONFormatter
 
 ```go
@@ -67,8 +54,8 @@ handling of error values
 ```go
 func (f *JSONFormatter) Format(entry *logrus.Entry) ([]byte, error)
 ```
-Format replaces any error field values with a FieldError and produces a JSON
-formatted log entry
+Format wraps the logrus.JSONFormatter.Format to pre-marshal wrapped errors
+rather than simply use the error message.
 
 --
 *Generated with [godocdown](https://github.com/robertkrimen/godocdown)*

--- a/pkg/logrusx/ext.go
+++ b/pkg/logrusx/ext.go
@@ -19,7 +19,7 @@ func DefaultSetup(logLevel string) error {
 func SetLevel(logLevel string) error {
 	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
-		return err
+		return errors.Wrapv(err, map[string]interface{}{"logLevel": logLevel})
 	}
 	logrus.SetLevel(level)
 	return nil

--- a/pkg/logrusx/formatter_test.go
+++ b/pkg/logrusx/formatter_test.go
@@ -50,7 +50,7 @@ func (s *FormatterTestSuite) TestJSONFormatterFormat() {
 	s.NoError(json.Unmarshal(jsonBytes, &loggedEntry))
 
 	errMap := loggedEntry["error"].(map[string]interface{})
-	s.Equal(errMap["Message"], testErr.Error())
+	s.Equal(errMap["cause"], testErr.Error())
 }
 
 func (s *FormatterTestSuite) TestJSONFormatterWithLogrus() {
@@ -64,6 +64,6 @@ func (s *FormatterTestSuite) TestJSONFormatterWithLogrus() {
 		s.Buffer.Truncate(0)
 
 		errMap := entry[fieldName].(map[string]interface{})
-		s.Equal(errMap["Message"], testErr.Error())
+		s.Equal(errMap["cause"], testErr.Error())
 	}
 }


### PR DESCRIPTION
#### Description:

Wrap errors in logrusx. Don't do its own stack tracing anymore. Pre-marshal to avoid logrus just turning them into strings. https://github.com/Sirupsen/logrus/blob/master/json_formatter.go#L20
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Related #308

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/346)

<!-- Reviewable:end -->
