### PR TITLE
pkg/errors - Prevent recursive error in MarshalJSON

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -49,6 +49,9 @@ func (e *errorExt) MarshalJSON() ([]byte, error) {
 		outputMap[k] = v
 	}
 	for k, v := range e.data {
+		if v == e {
+			continue
+		}
 		outputMap[k] = v
 	}
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -223,6 +223,7 @@ func (s *Errors) TestMarshalJSON() {
 	err := Wrap(origErr, ctx1)
 	err = Wrap(err, ctx2)
 	err = Wrapv(err, values)
+	err = Wrapv(err, map[string]interface{}{"self": err})
 
 	j, jmErr := json.Marshal(err)
 	if !s.NoError(jmErr, "failed to marshal error") {
@@ -269,6 +270,9 @@ func (s *Errors) TestMarshalJSON() {
 			s.EqualValues(v, valueI, "wrong value:"+k)
 		}
 	}
+
+	// self error should be omitted
+	s.Nil(output["self"])
 }
 
 func (s *Errors) TestCause() {


### PR DESCRIPTION
#### Description:

If an errorExt had itself in its data fields, leads to endless recursive JSON Marshaling and an out of memory error. Check to see if a data map value is the same as the error itself and if it is, omit it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/348)

<!-- Reviewable:end -->
