### PR TITLE
Add shellcheck and shfmt targets to main Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@ env:
     - VZFS=0.6.5.5
     - ZFS_CACHE=/tmp/zfs
 
+# https://github.com/koalaman/shellcheck/wiki/TravisCI
+addons:
+  apt:
+    sources:
+    - backports
+    packages:
+    - shellcheck
+
 cache:
   directories:
     - $ZFS_CACHE
@@ -35,12 +43,14 @@ install:
 
 before_script:
   - make lint-required
+  - make bash-lint-required
 
 script:
   - make test
 
 after_success:
   - make lint-optional
+  - make bash-lint-optional
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,6 @@ env:
     - VZFS=0.6.5.5
     - ZFS_CACHE=/tmp/zfs
 
-# https://github.com/koalaman/shellcheck/wiki/TravisCI
-addons:
-  apt:
-    sources:
-    - backports
-    packages:
-    - shellcheck
-
 cache:
   directories:
     - $ZFS_CACHE

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - DEBIAN_FRONTEND=noninteractive
     - DEBIAN_PRIORITY=critical
     - KV=consul
+    - SHELLCHECK_VERSION=0.4.4
     - VCONSUL=0.6.4
     - VETCD=2.1.1
     - VGLIDE=0.10.2
@@ -17,6 +18,7 @@ env:
 cache:
   directories:
     - $ZFS_CACHE
+    - $HOME/.cabal
 
 # Versions of Go and deps in the build matrix should test the current in use by
 # cerana-os and the latest release.
@@ -32,6 +34,7 @@ install:
   - glide install
   - .travis/deps.sh install
   - sudo modprobe zfs
+  - .travis/install-shellcheck.sh $SHELLCHECK_VERSION
 
 before_script:
   - make lint-required

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -35,6 +35,7 @@ function fetch() {
         | bsdtar -xf- -C$HOME/bin --strip-components=1 linux-amd64/glide
 
     go get github.com/alecthomas/gometalinter
+    go get github.com/mvdan/sh/cmd/shfmt
     gometalinter --install --update
 }
 

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -37,8 +37,6 @@ function fetch() {
     go get github.com/alecthomas/gometalinter
     gometalinter --install --update
     go get github.com/mvdan/sh/cmd/shfmt
-    curl -LO https://us-east.manta.joyent.com/nahamu/public/cerana/shellcheck_0.4.4_amd64.deb \
-        && sudo dpkg -i shellcheck_0.4.4_amd64.deb
 }
 
 function install() {

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -35,8 +35,10 @@ function fetch() {
         | bsdtar -xf- -C$HOME/bin --strip-components=1 linux-amd64/glide
 
     go get github.com/alecthomas/gometalinter
-    go get github.com/mvdan/sh/cmd/shfmt
     gometalinter --install --update
+    go get github.com/mvdan/sh/cmd/shfmt
+    curl -LO https://us-east.manta.joyent.com/nahamu/public/cerana/shellcheck_0.4.4_amd64.deb \
+        && sudo dpkg -i shellcheck_0.4.4_amd64.deb
 }
 
 function install() {

--- a/.travis/install-shellcheck.sh
+++ b/.travis/install-shellcheck.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o xtrace
+
+SHELLCHECK_VERSION="${1}"
+[[ -n "${SHELLCHECK_VERSION}" ]]
+
+check_and_install() {
+    ~/.cabal/bin/shellcheck --version | grep -q "${SHELLCHECK_VERSION}"
+    sudo install -D -m 755 -t /usr/local/bin ~/.cabal/bin/shellcheck
+    exit 0
+}
+
+if [[ -x ~/.cabal/bin/shellcheck ]]; then
+    # If we have a cached version sitting around
+    check_and_install
+else
+    # Build it!
+    sudo apt-get update
+    sudo apt-get install cabal-install
+    curl -L "https://github.com/koalaman/shellcheck/archive/v${SHELLCHECK_VERSION}.tar.gz" | tar xz
+    cd "shellcheck-${SHELLCHECK_VERSION}"
+    cabal update
+    cabal install
+    [[ -x ~/.cabal/bin/shellcheck ]]
+    check_and_install
+fi
+
+# Something went wrong.
+exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SHELL := /bin/bash
 
+# Bash scripts known to be lint-clean
+BASH_CLEAN=boot/*/*
+# Bash scripts not yet lint-clean
+BASH_DIRTY=build/*.sh build/scripts/cerana-functions.sh build/scripts/start-vm build/scripts/vm-network
+
 # Recursive wildcard function
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
@@ -38,6 +43,16 @@ lint-required:
 lint-optional:
 	gometalinter @gometalinter.optional.flags
 
+.PHONY: bash-lint-required
+bash-lint-required:
+	shfmt -i 4 -l $(BASH_CLEAN) | diff /dev/null -
+	shellcheck $(BASH_CLEAN)
+
+.PHONY: bash-lint-optional
+bash-lint-optional:
+	shfmt -i 4 -l $(BASH_DIRTY) | diff /dev/null -
+	shellcheck $(BASH_DIRTY)
+
 # Suppress Make output. The relevant test output will be collected and sent to
 # stdout
 .SILENT:
@@ -67,3 +82,7 @@ FORCE:
 
 clean:
 	go clean ./...
+
+.PHONY: shfmt
+shfmt:
+	shfmt -i 4 -w $(BASH_CLEAN) $(BASH_DIRTY)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # Bash scripts known to be lint-clean
 BASH_CLEAN=boot/*/*
 # Bash scripts not yet lint-clean
-BASH_DIRTY=build/*.sh build/scripts/cerana-functions.sh build/scripts/start-vm build/scripts/vm-network
+BASH_DIRTY=.travis/deps.sh build/*.sh build/scripts/cerana-functions.sh build/scripts/start-vm build/scripts/vm-network
 
 # Recursive wildcard function
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # Bash scripts known to be lint-clean
-BASH_CLEAN=boot/*/*
+BASH_CLEAN=boot/*/* .travis/install-shellcheck.sh
 # Bash scripts not yet lint-clean
 BASH_DIRTY=.travis/deps.sh build/*.sh build/scripts/cerana-functions.sh build/scripts/start-vm build/scripts/vm-network
 

--- a/boot/scripts/copy-platform.sh
+++ b/boot/scripts/copy-platform.sh
@@ -10,7 +10,7 @@ verify_existing() {
     [[ -n "${CERANA_INITRD_HASH}" ]] || return 1 # no checksum to verify
     DESTINATION="/data/platform/${CERANA_INITRD_HASH}"
     IFS=- read -r ALG HASH <<<"${CERANA_INITRD_HASH}"
-    type "${ALG}sum" || return 2                                # don't know how to verify this checksum
+    type "${ALG}sum" || return 2                                   # don't know how to verify this checksum
     "${ALG}sum" -c <<<"${HASH}  ${DESTINATION}/initrd" || return 3 # checksum failed
 }
 

--- a/build/jenkins.sh
+++ b/build/jenkins.sh
@@ -7,36 +7,35 @@ set -e
 # Don't override, as this is just a reference setup, and use from UI
 # can then change this, upgrade plugins, etc.
 copy_reference_file() {
-	f="${1%/}"
-	b="${f%.override}"
-	echo "$f" >> "$COPY_REFERENCE_FILE_LOG"
-	rel="${b:23}"
-	dir=$(dirname "${b}")
-	echo " $f -> $rel" >> "$COPY_REFERENCE_FILE_LOG"
-	if [[ ! -e $JENKINS_HOME/${rel} || $f = *.override ]]
-	then
-		echo "copy $rel to JENKINS_HOME" >> "$COPY_REFERENCE_FILE_LOG"
-		mkdir -p "$JENKINS_HOME/${dir:23}"
-		cp -r "${f}" "$JENKINS_HOME/${rel}";
-		# pin plugins on initial copy
-		[[ ${rel} == plugins/*.jpi ]] && touch "$JENKINS_HOME/${rel}.pinned"
-	fi;
+    f="${1%/}"
+    b="${f%.override}"
+    echo "$f" >>"$COPY_REFERENCE_FILE_LOG"
+    rel="${b:23}"
+    dir=$(dirname "${b}")
+    echo " $f -> $rel" >>"$COPY_REFERENCE_FILE_LOG"
+    if [[ ! -e $JENKINS_HOME/${rel} || $f = *.override ]]; then
+        echo "copy $rel to JENKINS_HOME" >>"$COPY_REFERENCE_FILE_LOG"
+        mkdir -p "$JENKINS_HOME/${dir:23}"
+        cp -r "${f}" "$JENKINS_HOME/${rel}"
+        # pin plugins on initial copy
+        [[ ${rel} == plugins/*.jpi ]] && touch "$JENKINS_HOME/${rel}.pinned"
+    fi
 }
 # : ${JENKINS_HOME:="/var/jenkins_home"}
 export -f copy_reference_file
 mkdir -p ${JENKINS_HOME}
 touch "${COPY_REFERENCE_FILE_LOG}" || (echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?" && exit 1)
-echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
+echo "--- Copying files at $(date)" >>"$COPY_REFERENCE_FILE_LOG"
 find /usr/share/jenkins/ref/ -type f -exec bash -c "copy_reference_file '{}'" \;
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-	# Much of this depends upon nix so be sure it's installed before running
-	# Jenkins.
-	if [ ! -f  ~/.nix-profile/etc/profile.d/nix.sh ]; then
-		cd ~ && curl https://nixos.org/nix/install | sh
-	fi
-	eval "exec java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war $JENKINS_OPTS \"\$@\""
+    # Much of this depends upon nix so be sure it's installed before running
+    # Jenkins.
+    if [ ! -f ~/.nix-profile/etc/profile.d/nix.sh ]; then
+        cd ~ && curl https://nixos.org/nix/install | sh
+    fi
+    eval "exec java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war $JENKINS_OPTS \"\$@\""
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image

--- a/build/plugins.sh
+++ b/build/plugins.sh
@@ -14,15 +14,15 @@ REF=/usr/share/jenkins/ref/plugins
 mkdir -p $REF
 
 while read spec || [ -n "$spec" ]; do
-    plugin=(${spec//:/ });
+    plugin=(${spec//:/ })
     [[ ${plugin[0]} =~ ^# ]] && continue
     [[ ${plugin[0]} =~ ^\s*$ ]] && continue
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
     echo "Downloading ${plugin[0]}:${plugin[1]}"
 
     if [ -z "$JENKINS_UC_DOWNLOAD" ]; then
-      JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
+        JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
     curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
     unzip -qqt $REF/${plugin[0]}.jpi
-done  < $1
+done <$1

--- a/build/scripts/cerana-functions.sh
+++ b/build/scripts/cerana-functions.sh
@@ -32,7 +32,7 @@ function set_test_default() {
     #   1: option name
     #   2: value
     mkdir -p $(dirname $testceranastatedir/$1)
-    echo "$2">$testceranastatedir/$1
+    echo "$2" >$testceranastatedir/$1
     verbose The test default $1 has been set to $2
 }
 
@@ -163,29 +163,29 @@ white='\e[1;37m'$darkgreybg
 nc='\e[0m'
 id=$(basename $0)
 
-message () {
+message() {
     echo -e "$green$id$nc: $*"
 }
 
-tip () {
+tip() {
     echo -e "$green$id$nc: $white$*$nc"
 }
 
-warning () {
+warning() {
     echo -e "$green$id$yellow WARNING$nc: $*"
 }
 
-error () {
+error() {
     echo >&2 -e "$green$id$red ERROR$nc: $*"
 }
 
-verbose () {
+verbose() {
     if [[ "$verbose" == "y" ]]; then
         echo >&2 -e "$lightblue$id$nc: $*"
     fi
 }
 
-log () {
+log() {
     echo $* >>$testlogdir/$testlog
     verbose "$*"
 }
@@ -202,36 +202,36 @@ function die() {
 function run() {
     verbose "Running: '$@'"
     if [ -z "$dryrun" ]; then
-        "$@"; code=$?; [ $code -ne 0 ] && die "Command [$*] returned status code $code";
+        "$@"
+        code=$?
+        [ $code -ne 0 ] && die "Command [$*] returned status code $code"
         return $code
-    else
-        return 0
-    fi
+    else return 0; fi
 }
 
-function run_ignore {
+function run_ignore() {
     verbose "Running: '$@'"
     if [ -z "$dryrun" ]; then
-        "$@"; code=$?; [ $code -ne 0 ] && verbose "Command [$*] returned status code $code";
+        "$@"
+        code=$?
+        [ $code -ne 0 ] && verbose "Command [$*] returned status code $code"
         return $code
-    else
-        return 0
-    fi
+    else return 0; fi
 }
 
-function confirm () {
+function confirm() {
     read -r -p "${1:-Are you sure? [y/N]} " response
     case $response in
-    [yY][eE][sS]|[yY])
-        true
-        ;;
-    *)
-        false
-        ;;
+        [yY][eE][sS] | [yY])
+            true
+            ;;
+        *)
+            false
+            ;;
     esac
 }
 
-is_mounted () {
+is_mounted() {
     mount | grep $1
     return $?
 }

--- a/build/scripts/start-vm
+++ b/build/scripts/start-vm
@@ -14,8 +14,8 @@
 
 source `dirname "$(readlink -f "$0")"`/cerana-functions.sh
 
-usage () {
-cat << EOF
+usage() {
+    cat <<EOF
 Usage: $0 [options]
     Use this script to start a virtual machine running CeranaOS.
 
@@ -163,7 +163,7 @@ resetdefaults,\
 verbose,\
 dryrun,\
 help" \
-   -o "h" -- "$@"`
+    -o "h" -- "$@"`
 
 if [ $? -gt 0 ]; then
     usage
@@ -270,7 +270,7 @@ while [ $# -ge 1 ]; do
         --dryrun)
             dryrun=echo
             ;;
-        -h|--help)
+        -h | --help)
             showusage=y
             ;;
         # using getopt should avoid needing this catchall but just in case...
@@ -311,8 +311,7 @@ statevars=(
     job=build-cerana
     build=""
 )
-for v in "${statevars[@]}"
-do
+for v in "${statevars[@]}"; do
     if [ ! -z "$resetdefaults" ]; then
         clear_test_variable $config/$v
     fi
@@ -343,8 +342,7 @@ if [ -n "$download" ]; then
     fi
     verbose Downloading $job/$build images
     run mkdir -p $ceranaimagedir/$job/$build
-    for f in bzImage initrd cerana.iso
-    do
+    for f in bzImage initrd cerana.iso; do
         df=$ceranaimagedir/$job/$build/$f
         verbose df
         # TODO Added verification of MD5 sums.
@@ -356,11 +354,10 @@ if [ -n "$download" ]; then
         fi
     done
     verbose Setting image symlinks.
-    for f in $kernelimage $initrdimage $isoimage
-    do
+    for f in $kernelimage $initrdimage $isoimage; do
         verbose Checking $f for symlink.
         e=0
-        if [ -e  $ceranaimagedir/$f ]; then
+        if [ -e $ceranaimagedir/$f ]; then
             if [ -h $ceranaimagedir/$f ]; then
                 verbose Replacing symlink $ceranaimagedir/$f
                 rm $ceranaimagedir/$f
@@ -369,7 +366,7 @@ if [ -n "$download" ]; then
                 e=1
             fi
         else
-            verbose The file  $ceranaimagedir/$f does not exist.
+            verbose The file $ceranaimagedir/$f does not exist.
         fi
     done
     if [ $e -gt 0 ]; then
@@ -443,12 +440,12 @@ case "$boot" in
         verbose The initrd image is: $initrd
 
         $dryrun kvm \
-        $commonoptions \
-        $disklist \
-        $devicelist \
-        -kernel $kernel \
-        -initrd $initrd \
-        -append "noapic acpi=off console=ttyS0 cerana.zfs_config=auto"
+            $commonoptions \
+            $disklist \
+            $devicelist \
+            -kernel $kernel \
+            -initrd $initrd \
+            -append "noapic acpi=off console=ttyS0 cerana.zfs_config=auto"
         ;;
 
     iso)
@@ -459,20 +456,20 @@ case "$boot" in
 
         verbose Booting from ISO image.
         $dryrun kvm \
-        $commonoptions \
-        $disklist \
-        $devicelist \
-        -cdrom $iso \
-        -boot d
+            $commonoptions \
+            $disklist \
+            $devicelist \
+            -cdrom $iso \
+            -boot d
         ;;
 
     net)
         verbose Booting from ISO image.
         $dryrun kvm \
-        $commonoptions \
-        $disklist \
-        $devicelist \
-        -option-rom $pxeoptionrom -boot n
+            $commonoptions \
+            $disklist \
+            $devicelist \
+            -option-rom $pxeoptionrom -boot n
         ;;
 
     *)

--- a/build/scripts/vm-network
+++ b/build/scripts/vm-network
@@ -33,7 +33,7 @@ statevars=(
 
 u=$USER
 
-usage () {
+usage() {
     warning +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     message This script uses sudo to run as root and can break an existing
     message network configuration. Use with caution!
@@ -47,7 +47,7 @@ usage () {
     message e.g. sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.dhcpd
     warning ----------------------------------------------------------------
 
-    cat << EOF
+    cat <<EOF
 Usage: $0 [options]
     Use this script to configure the local network for testing CeranaOS within
     a virtual machine.
@@ -158,7 +158,7 @@ function shutdowndhcpd() {
     verbose Shutting down the dhcp server.
     ps -C dhcpd
     if [ $? -gt 0 ]; then
-        message  The dhcp server is not running.
+        message The dhcp server is not running.
     else
         ps -fp `pgrep dhcpd` | grep $dhcpdconf
         if [ $? -gt 0 ]; then
@@ -169,7 +169,7 @@ function shutdowndhcpd() {
         else
             message Shutting down the dhcp server.
             sudo kill `pidof dhcpd`
-            message  The dhcp server has been shut down.
+            message The dhcp server has been shut down.
         fi
     fi
 }
@@ -186,8 +186,7 @@ function shutdown() {
         check_interface_exists $b
         if [ $? -eq 0 ]; then
             sudo ip link set $b down
-            for i in `brctl showstp $b | grep $2 | cut -d ' ' -f 1`
-            do
+            for i in `brctl showstp $b | grep $2 | cut -d ' ' -f 1`; do
                 check_interface_exists $i
                 if [ $? -eq 0 ]; then
                     verbose Shutting down $i
@@ -204,16 +203,15 @@ function shutdown() {
     done
 }
 
-function init_variables () {
+function init_variables() {
     # Parameters:
     #   1: The name of the configuration to use.
-    for v in "${statevars[@]}"
-    do
+    for v in "${statevars[@]}"; do
         init_test_variable $1/$v
     done
 }
 
-function build_bridges () {
+function build_bridges() {
     # Parameters:
     #   1: The number of bridges to build.
     #   2: The base name for each bridge.
@@ -241,7 +239,7 @@ function build_bridges () {
     done
 }
 
-function set_bridge_1_address () {
+function set_bridge_1_address() {
     # Parameters:
     #   1: The base name for each bridge.
     #   2: The base IP address for each bridge.
@@ -261,7 +259,7 @@ function set_bridge_1_address () {
     fi
 }
 
-function enable_bridges () {
+function enable_bridges() {
     # Parameters:
     #   1: The number of bridges to enable.
     #   2: The base name for each bridge.
@@ -281,7 +279,7 @@ function enable_bridges () {
     done
 }
 
-function build_taps () {
+function build_taps() {
     # Parameters:
     #   1: The number of tap sets to build.
     #   2: The number of taps per taps set to build.
@@ -337,7 +335,7 @@ resetdefaults,\
 verbose,\
 dryrun,\
 help" \
-   -o "h" -- "$@"`
+    -o "h" -- "$@"`
 
 if [ $? -gt 0 ]; then
     usage
@@ -417,7 +415,7 @@ while [ $# -ge 1 ]; do
         --dryrun)
             dryrun=y
             ;;
-        -h|--help)
+        -h | --help)
             showusage=y
             ;;
         # using getopt should avoid needing this catchall but just in case...
@@ -474,9 +472,9 @@ fi
 
 if [ "$config" != "$current" ]; then
     verbose Switching from $current to $config
-    b=$(get_test_default $current/bridge "" )
-    t=$(get_test_default $current/tap "" )
-    n=$(get_test_default $current/numtaps "" )
+    b=$(get_test_default $current/bridge "")
+    t=$(get_test_default $current/tap "")
+    n=$(get_test_default $current/numtaps "")
     shutdown $b $t $n
 fi
 
@@ -559,7 +557,7 @@ else
         message Using subnet $subnet.0
         run rm -f $dhcpdconf
         run sudo touch $leasesfile
-        cat << EOF >>$dhcpdconf
+        cat <<EOF >>$dhcpdconf
         ###
         subnet $subnet.0 netmask 255.255.255.0 {
         range $subnet.$dhcplow $subnet.$dhcphigh;


### PR DESCRIPTION
#### Description:
- Make it easier to enforce shellcheck and shfmt across the whole repo.
- Update the Travis environment to be able to run shellcheck and shfmt so that we can enable these for CI testing.

Future work:
- Make everying under `build/` report clean with these targets

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/353)

<!-- Reviewable:end -->
