### PR TITLE
Call errors.ResetStack on resp.Error

### DIFF
--- a/acomm/response.go
+++ b/acomm/response.go
@@ -123,7 +123,7 @@ func sendUnix(addr *url.URL, payload interface{}) error {
 		return err
 	}
 
-	return resp.Error
+	return errors.ResetStack(resp.Error)
 }
 
 // sendHTTP sends the Response via HTTP/HTTPS
@@ -145,5 +145,5 @@ func sendHTTP(addr *url.URL, payload interface{}) error {
 		return errors.Wrapv(err, map[string]interface{}{"body": string(body)})
 	}
 
-	return resp.Error
+	return errors.ResetStack(resp.Error)
 }

--- a/acomm/tracker.go
+++ b/acomm/tracker.go
@@ -471,7 +471,7 @@ func (t *Tracker) SyncRequest(dest *url.URL, opts RequestOptions, timeout time.D
 	}
 
 	resp := <-ch
-	return resp, resp.Error
+	return resp, errors.ResetStack(resp.Error)
 }
 
 // ReplaceLocalhost replaces localhost, 127.0.0.1, or ::1 with the specified host.

--- a/cmd/bundle-heartbeat/bundle.go
+++ b/cmd/bundle-heartbeat/bundle.go
@@ -65,7 +65,7 @@ func getBundles(config tick.Configer, tracker *acomm.Tracker) ([]*clusterconf.Bu
 	for name, args := range requests {
 		resp := responses[name]
 		if resp.Error != nil {
-			return nil, errors.Wrap(resp.Error)
+			return nil, errors.ResetStack(resp.Error)
 		}
 		if err := resp.UnmarshalResult(args.respData); err != nil {
 			return nil, err
@@ -119,7 +119,7 @@ func getSerial(config tick.Configer, tracker *acomm.Tracker) (string, error) {
 
 	resp := <-doneChan
 	if resp.Error != nil {
-		return "", errors.Wrap(resp.Error)
+		return "", errors.ResetStack(resp.Error)
 	}
 
 	var data host.InfoStat
@@ -217,7 +217,7 @@ func runHealthChecks(config tick.Configer, tracker *acomm.Tracker, bundles []*cl
 			healthResults[bundleID] = make(map[string]error)
 		}
 		if resp.Error != nil {
-			healthResults[bundleID][healthCheck] = errors.Wrap(resp.Error)
+			healthResults[bundleID][healthCheck] = errors.ResetStack(resp.Error)
 		}
 	}
 

--- a/cmd/dataset-heartbeat/dataset.go
+++ b/cmd/dataset-heartbeat/dataset.go
@@ -65,7 +65,7 @@ func getDatasets(config *Config, tracker *acomm.Tracker, ip net.IP) ([]clusterco
 	for name, args := range requests {
 		resp := responses[name]
 		if resp.Error != nil {
-			return nil, errors.Wrap(resp.Error)
+			return nil, errors.ResetStack(resp.Error)
 		}
 		if err := resp.UnmarshalResult(args.respData); err != nil {
 			return nil, err

--- a/cmd/node-heartbeat/node.go
+++ b/cmd/node-heartbeat/node.go
@@ -55,7 +55,7 @@ func getNodeInfo(config tick.Configer, tracker *acomm.Tracker, ip net.IP) (*clus
 	for name := range requests {
 		resp := responses[name]
 		if resp.Error != nil {
-			return nil, errors.Wrapv(resp.Error, map[string]interface{}{"task": name})
+			return nil, errors.Wrapv(errors.ResetStack(resp.Error), map[string]interface{}{"task": name})
 		}
 		if err := resp.UnmarshalResult(tasks[name]); err != nil {
 			return nil, err
@@ -95,5 +95,5 @@ func sendNodeHeartbeat(config tick.Configer, tracker *acomm.Tracker, data *clust
 	if err != nil {
 		return err
 	}
-	return errors.Wrap(resp.Error)
+	return errors.ResetStack(resp.Error)
 }

--- a/pkg/errors/README.md
+++ b/pkg/errors/README.md
@@ -39,6 +39,14 @@ func Newv(msg string, values map[string]interface{}) error
 Newv returns a new error with the callstack that formats as the given text and
 associates the supplied data with the error.
 
+#### func  ResetStack
+
+```go
+func ResetStack(err error) error
+```
+ResetStack generates a new stack trace for the error at the current location if
+one was present.
+
 #### func  Wrap
 
 ```go

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -159,6 +159,23 @@ func Wrapv(err error, values map[string]interface{}, msg ...string) error {
 	return eExt
 }
 
+// ResetStack generates a new stack trace for the error at the current location
+// if one was present.
+func ResetStack(err error) error {
+	eExt, ok := err.(*errorExt)
+	if !ok {
+		return err
+	}
+
+	// Skip 3 for getPCs:
+	// 0 : runtime.Callers
+	// 1 : errors.getPCs
+	// 2 : errors.ResetStack
+	// 3 : {API caller}
+	eExt.pcs = getPCs(3)
+	return eExt
+}
+
 func getPCs(skip int) []uintptr {
 	pcs := make([]uintptr, stackDepth)
 	n := runtime.Callers(skip, pcs)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -161,6 +161,12 @@ func Wrapv(err error, values map[string]interface{}, msg ...string) error {
 
 // ResetStack generates a new stack trace for the error at the current location
 // if one was present.
+// This is useful when the original stack trace is too generic to be useful,
+// such as a generic goroutine handling communication processing and relaying
+// errors back to the original caller. Every error would have the generic
+// goroutine stack trace when wrapped. Allowing the stack to be recaptured at
+// the point where the error arrives back at the original caller provides much
+// more useful information.
 func ResetStack(err error) error {
 	eExt, ok := err.(*errorExt)
 	if !ok {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -286,3 +286,21 @@ func (s *Errors) TestCause() {
 	s.Equal(err, Cause(wrapped))
 	s.NotEqual(wrapped, Cause(wrapped))
 }
+
+func resetFirst() *errorExt {
+	return New("first").(*errorExt)
+}
+
+func resetSecond(err error) *errorExt {
+	return ResetStack(err).(*errorExt)
+}
+
+func (s *Errors) TestResetStack() {
+	err := resetFirst()
+	stack := callstack(err.pcs)
+	s.Contains(stack[0], "resetFirst")
+
+	err = resetSecond(err)
+	stack = callstack(err.pcs)
+	s.Contains(stack[0], "resetSecond")
+}

--- a/providers/clusterconf/README.md
+++ b/providers/clusterconf/README.md
@@ -452,10 +452,10 @@ ConfigData defines the structure of the config data (e.g. in the config file)
 
 ```go
 type DHCPConfig struct {
-	DNS      []net.IP      `json:"dns"`
-	Duration time.Duration `json:"duration"`
-	Gateway  net.IP        `json:"gateway"`
-	Net      net.IPNet     `json:"net"`
+	DNS      []string `json:"dns"`
+	Duration string   `json:"duration"`
+	Gateway  string   `json:"gateway"`
+	Net      string   `json:"net"`
 }
 ```
 

--- a/providers/clusterconf/clusterconf.go
+++ b/providers/clusterconf/clusterconf.go
@@ -97,7 +97,7 @@ func (c *ClusterConf) kvReq(task string, args map[string]interface{}) (*acomm.Re
 	}
 
 	resp := <-respChan
-	return resp, errors.Wrapv(resp.Error, errData)
+	return resp, errors.Wrapv(errors.ResetStack(resp.Error), errData)
 }
 
 func (c *ClusterConf) kvKeys(prefix string) ([]string, error) {

--- a/providers/dhcp/main.go
+++ b/providers/dhcp/main.go
@@ -1,7 +1,6 @@
 package dhcp
 
 import (
-	"errors"
 	"math/rand"
 	"net"
 	"net/url"
@@ -9,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/errors"
 	"github.com/cerana/cerana/provider"
 	"github.com/cerana/cerana/providers/kv"
 	"github.com/krolaw/dhcp4"
@@ -151,7 +151,7 @@ func refreshLeaseAck(tracker *acomm.Tracker, coord *url.URL, mac, ip string, ttl
 	}
 
 	resp := <-ch
-	return resp.Error
+	return errors.ResetStack(resp.Error)
 }
 
 func nextGetter(closer <-chan struct{}, taken []uint32, min, max uint32) <-chan uint32 {

--- a/providers/health/file.go
+++ b/providers/health/file.go
@@ -1,11 +1,11 @@
 package health
 
 import (
-	"errors"
 	"net/url"
 	"os"
 
 	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/errors"
 )
 
 // FileArgs are arguments for the File health check.
@@ -25,7 +25,7 @@ func (h *Health) File(req *acomm.Request) (interface{}, *url.URL, error) {
 	}
 
 	if args.Path == "" {
-		return nil, nil, errors.New("missing arg: path")
+		return nil, nil, errors.Newv("missing arg: path", map[string]interface{}{"args": args, "missing": "path"})
 	}
 
 	fileInfo, err := os.Stat(args.Path)
@@ -33,19 +33,19 @@ func (h *Health) File(req *acomm.Request) (interface{}, *url.URL, error) {
 		if args.NotExist && os.IsNotExist(err) {
 			return nil, nil, nil
 		}
-		return nil, nil, err
+		return nil, nil, errors.Wrapv(err, map[string]interface{}{"path": args.Path})
 	} else if args.NotExist {
-		return nil, nil, errors.New("file exists")
+		return nil, nil, errors.Newv("file exists", map[string]interface{}{"path": args.Path})
 	}
 
 	if args.Mode != 0 && (args.Mode&fileInfo.Mode() != args.Mode) {
-		return nil, nil, errors.New("unexpected mode")
+		return nil, nil, errors.Newv("unexpected mode", map[string]interface{}{"expectedMode": args.Mode, "mode": fileInfo.Mode()})
 	}
 	if fileInfo.Size() < args.MinSize {
-		return nil, nil, errors.New("size below min")
+		return nil, nil, errors.Newv("size below min", map[string]interface{}{"minSize": args.MinSize, "size": fileInfo.Size()})
 	}
 	if args.MaxSize > 0 && fileInfo.Size() > args.MaxSize {
-		return nil, nil, errors.New("size above max")
+		return nil, nil, errors.Newv("size above max", map[string]interface{}{"maxSize": args.MinSize, "size": fileInfo.Size()})
 	}
 
 	return nil, nil, nil

--- a/providers/health/httpstatus.go
+++ b/providers/health/httpstatus.go
@@ -2,11 +2,11 @@ package health
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
 	"net/url"
 
 	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/errors"
 	"github.com/cerana/cerana/pkg/logrusx"
 )
 
@@ -27,7 +27,7 @@ func (h *Health) HTTPStatus(req *acomm.Request) (interface{}, *url.URL, error) {
 	}
 
 	if args.URL == "" {
-		return nil, nil, errors.New("missing arg: url")
+		return nil, nil, errors.Newv("missing arg: url", map[string]interface{}{"args": args, "missing": "url"})
 	}
 
 	if args.StatusCode == 0 {
@@ -37,12 +37,12 @@ func (h *Health) HTTPStatus(req *acomm.Request) (interface{}, *url.URL, error) {
 	httpReq, err := http.NewRequest(args.Method, args.URL, bytes.NewReader(args.Body))
 	httpResp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrapv(err, map[string]interface{}{"args": args})
 	}
 	defer logrusx.LogReturnedErr(httpResp.Body.Close, nil, "failed to close resp body")
 
 	if httpResp.StatusCode != args.StatusCode {
-		err = errors.New("unexpected response status code")
+		err = errors.Newv("unexpected response status code", map[string]interface{}{"expectedStatusCode": args.StatusCode, "statusCode": httpResp.StatusCode})
 	}
 
 	return nil, nil, err

--- a/providers/health/mock.go
+++ b/providers/health/mock.go
@@ -1,10 +1,10 @@
 package health
 
 import (
-	"errors"
 	"net/url"
 
 	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/errors"
 	"github.com/cerana/cerana/provider"
 )
 

--- a/providers/health/tcpresponse.go
+++ b/providers/health/tcpresponse.go
@@ -1,13 +1,13 @@
 package health
 
 import (
-	"errors"
 	"io/ioutil"
 	"net"
 	"net/url"
 	"regexp"
 
 	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/errors"
 	"github.com/cerana/cerana/pkg/logrusx"
 )
 
@@ -27,37 +27,37 @@ func (h *Health) TCPResponse(req *acomm.Request) (interface{}, *url.URL, error) 
 	}
 
 	if args.Address == "" {
-		return nil, nil, errors.New("missing arg: address")
+		return nil, nil, errors.Newv("missing arg: address", map[string]interface{}{"args": args, "missing": "address"})
 	}
 	if args.Regexp == "" {
-		return nil, nil, errors.New("missing arg: regexp")
+		return nil, nil, errors.Newv("missing arg: regexp", map[string]interface{}{"args": args, "missing": "regexp"})
 	}
 	re, err := regexp.Compile(args.Regexp)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrapv(err, map[string]interface{}{"regexp": args.Regexp})
 	}
 
 	conn, err := net.DialTimeout("tcp", args.Address, h.config.RequestTimeout())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrapv(err, map[string]interface{}{"type": "tcp", "addr": args.Address, "timeout": h.config.RequestTimeout()})
 	}
 	defer logrusx.LogReturnedErr(conn.Close, nil, "failed to close tcp conn")
 	if len(args.Body) > 0 {
 		if _, err = conn.Write(args.Body); err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Wrapv(err, map[string]interface{}{"addr": args.Address, "body": string(args.Body)})
 		}
 		if err = conn.(*net.TCPConn).CloseWrite(); err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Wrapv(err, map[string]interface{}{"addr": args.Address})
 		}
 	}
 
 	tcpResp, err := ioutil.ReadAll(conn)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err)
 	}
 
 	if !re.Match(tcpResp) {
-		return nil, nil, errors.New("response did not match")
+		return nil, nil, errors.Newv("response did not match", map[string]interface{}{"regexp": args.Regexp, "tcpResponse": string(tcpResp)})
 	}
 	return nil, nil, nil
 }

--- a/providers/health/uptime.go
+++ b/providers/health/uptime.go
@@ -1,11 +1,11 @@
 package health
 
 import (
-	"errors"
 	"net/url"
 	"time"
 
 	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/errors"
 	"github.com/cerana/cerana/providers/systemd"
 )
 
@@ -22,7 +22,7 @@ func (h *Health) Uptime(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, err
 	}
 	if args.Name == "" {
-		return nil, nil, errors.New("missing arg: name")
+		return nil, nil, errors.Newv("missing arg: name", map[string]interface{}{"args": args, "missing": "name"})
 	}
 
 	unitStatus, err := h.getUnitStatus(args.Name)
@@ -31,7 +31,7 @@ func (h *Health) Uptime(req *acomm.Request) (interface{}, *url.URL, error) {
 	}
 
 	if unitStatus.Uptime < args.MinUptime {
-		return nil, nil, errors.New("uptime less than expected")
+		return nil, nil, errors.Newv("uptime less than expected", map[string]interface{}{"minUptime": args.MinUptime, "uptime": unitStatus.Uptime})
 	}
 
 	return nil, nil, nil
@@ -62,7 +62,7 @@ func (h *Health) getUnitStatus(name string) (*systemd.UnitStatus, error) {
 
 	resp := <-doneChan
 	if resp.Error != nil {
-		return nil, resp.Error
+		return nil, errors.ResetStack(resp.Error)
 	}
 
 	var result systemd.GetResult

--- a/providers/service/get.go
+++ b/providers/service/get.go
@@ -88,7 +88,7 @@ func (p *Provider) getService(bundleID uint64, id string) (*Service, error) {
 
 	resp := <-ch
 	if resp.Error != nil {
-		return nil, errors.Wrap(resp.Error)
+		return nil, errors.ResetStack(resp.Error)
 	}
 
 	var getResult systemd.GetResult

--- a/providers/service/list.go
+++ b/providers/service/list.go
@@ -39,7 +39,7 @@ func (p *Provider) List(req *acomm.Request) (interface{}, *url.URL, error) {
 
 	resp := <-ch
 	if resp.Error != nil {
-		return nil, nil, errors.Wrap(resp.Error)
+		return nil, nil, errors.ResetStack(resp.Error)
 	}
 
 	var listResult systemd.ListResult

--- a/providers/service/restart.go
+++ b/providers/service/restart.go
@@ -53,5 +53,5 @@ func (p *Provider) Restart(req *acomm.Request) (interface{}, *url.URL, error) {
 	}
 
 	resp := <-ch
-	return nil, nil, errors.Wrap(resp.Error)
+	return nil, nil, errors.ResetStack(resp.Error)
 }

--- a/providers/service/service.go
+++ b/providers/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/cerana/cerana/acomm"
+	"github.com/cerana/cerana/pkg/errors"
 	"github.com/cerana/cerana/provider"
 )
 
@@ -47,7 +48,7 @@ func (p *Provider) executeRequests(requests []*acomm.Request) error {
 
 		resp := <-doneChan
 		if resp.Error != nil {
-			return resp.Error
+			return errors.ResetStack(resp.Error)
 		}
 	}
 	return nil

--- a/tick/tick.go
+++ b/tick/tick.go
@@ -86,7 +86,7 @@ func GetIP(config Configer, tracker *acomm.Tracker) (net.IP, error) {
 		return nil, err
 	}
 	if resp.Error != nil {
-		return nil, errors.Wrap(resp.Error)
+		return nil, errors.ResetStack(resp.Error)
 	}
 
 	var data metrics.NetworkResult


### PR DESCRIPTION
#### Description:

When a response is received by an acomm.Tracker, it is wrapped to associate the request id. Unfortunately, this creates an identical stack trace for each, just the response handling goroutine. Using errors.ResetStack on it once back in the main code gives a more useful trace to find out where that resp.Error is gotten.

Additionally, wrap errors in providers/health since that had been missed and would be affected by this change.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #XXXX

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/357)

<!-- Reviewable:end -->
