### PR TITLE
Allow service unit file updates

### DIFF
--- a/providers/service/README.md
+++ b/providers/service/README.md
@@ -74,10 +74,11 @@ type CreateArgs struct {
 	Description string            `json:"description"`
 	Cmd         []string          `json:"cmd"`
 	Env         map[string]string `json:"env"`
+	Overwrite   bool              `json:"overwrite"`
 }
 ```
 
-CreateArgs contains args for creating a new Service.
+CreateArgs contains args for creating or replacing a Service.
 
 #### type GetArgs
 
@@ -214,7 +215,7 @@ New creates a new instance of Provider.
 ```go
 func (p *Provider) Create(req *acomm.Request) (interface{}, *url.URL, error)
 ```
-Create creates and starts a new service.
+Create creates (or replaces) and starts (or restarts) a service.
 
 #### func (*Provider) Get
 

--- a/providers/service/create.go
+++ b/providers/service/create.go
@@ -114,7 +114,7 @@ func (p *Provider) prepareCreateRequests(name string, unitOptions []*unit.UnitOp
 	// there's only more work to do if the unit was modified
 	continueChecks = append(continueChecks, func(resp *acomm.Response) (bool, error) {
 		var result systemd.CreateResult
-		if err := resp.UnmarshalResult(&result); err != nil {
+		if err = resp.UnmarshalResult(&result); err != nil {
 			return false, err
 		}
 		return result.UnitModified, nil

--- a/providers/service/remove.go
+++ b/providers/service/remove.go
@@ -33,7 +33,7 @@ func (p *Provider) Remove(req *acomm.Request) (interface{}, *url.URL, error) {
 		return nil, nil, err
 	}
 
-	return nil, nil, p.executeRequests(requests)
+	return nil, nil, p.executeRequests(requests, nil)
 }
 
 func (p *Provider) prepareRemoveRequests(name string) ([]*acomm.Request, error) {

--- a/providers/systemd/README.md
+++ b/providers/systemd/README.md
@@ -83,6 +83,7 @@ ConfigData defines the structure of the config data (e.g. in the config file)
 type CreateArgs struct {
 	Name        string             `json:"name"`
 	UnitOptions []*unit.UnitOption `json:"unit-options"`
+	Overwrite   bool               `json:"overwrite"`
 }
 ```
 

--- a/providers/systemd/README.md
+++ b/providers/systemd/README.md
@@ -89,6 +89,16 @@ type CreateArgs struct {
 
 CreateArgs are arguments for the Create handler.
 
+#### type CreateResult
+
+```go
+type CreateResult struct {
+	UnitModified bool `json:"modified"`
+}
+```
+
+CreateResult is the result of a create action.
+
 #### type DisableArgs
 
 ```go
@@ -299,7 +309,7 @@ New creates a new instance of Systemd.
 ```go
 func (s *Systemd) Create(req *acomm.Request) (interface{}, *url.URL, error)
 ```
-Create creates a new unit file.
+Create creates or overwrites a unit file.
 
 #### func (*Systemd) Disable
 

--- a/providers/systemd/create_test.go
+++ b/providers/systemd/create_test.go
@@ -12,18 +12,20 @@ import (
 
 func (s *systemd) TestCreate() {
 	tests := []struct {
-		name    string
-		options []*unit.UnitOption
-		err     string
+		name      string
+		options   []*unit.UnitOption
+		overwrite bool
+		err       string
 	}{
-		{"", nil, "missing arg: name"},
-		{"empty.service", nil, ""},
-		{"nonempty.service", []*unit.UnitOption{{"foo", "bar", "baz"}}, ""},
-		{"nonempty.service", []*unit.UnitOption{{"foo2", "bar2", "baz2"}}, "unit file already exists"}, // duplicate
+		{"", nil, false, "missing arg: name"},
+		{"empty.service", nil, false, ""},
+		{"nonempty.service", []*unit.UnitOption{{"foo", "bar", "baz"}}, false, ""},
+		{"nonempty.service", []*unit.UnitOption{{"foo2", "bar2", "baz2"}}, false, "unit file already exists"}, // duplicate
+		{"nonempty.service", []*unit.UnitOption{{"foo2", "bar2", "baz2"}}, true, ""},
 	}
 
 	for _, test := range tests {
-		args := &systemdp.CreateArgs{Name: test.name, UnitOptions: test.options}
+		args := &systemdp.CreateArgs{Name: test.name, UnitOptions: test.options, Overwrite: test.overwrite}
 		argsS := fmt.Sprintf("%+v", args)
 
 		req, err := acomm.NewRequest(acomm.RequestOptions{


### PR DESCRIPTION
#### Description:

Add an `overwrite` bool argument to the systemd create task, passed through the service create task. This essentially disables the unit file existence check, allowing a unit file to be overwritten with new options. Systemd-create now calls `dbus.Reload()` at the end (effectively `systemctl daemon reload`. The service create task can remain mostly the same since the enable call will succeed even when already enabled and the restart call will restart or start a service.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #359

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/361)

<!-- Reviewable:end -->
