### PR TITLE
cmd/bundle-heartbeat - Don't skip bundles without health checks defined

### DIFF
--- a/cmd/bundle-heartbeat/bundle.go
+++ b/cmd/bundle-heartbeat/bundle.go
@@ -209,13 +209,14 @@ func runHealthChecks(config tick.Configer, tracker *acomm.Tracker, bundles []*cl
 
 	responses := multiRequest.Responses()
 	healthResults := make(map[uint64]map[string]error)
+	for _, bundle := range bundles {
+		healthResults[bundle.ID] = make(map[string]error)
+	}
+
 	for name, resp := range responses {
 		nameParts := strings.Split(name, ":")
 		bundleID, _ := strconv.ParseUint(nameParts[0], 10, 64)
 		healthCheck := nameParts[1] + ":" + nameParts[2]
-		if _, ok := healthResults[bundleID]; !ok {
-			healthResults[bundleID] = make(map[string]error)
-		}
 		if resp.Error != nil {
 			healthResults[bundleID][healthCheck] = errors.Wrap(resp.Error)
 		}


### PR DESCRIPTION
#### Description:

Previously, if a bundle had no health checks defined, it wasn't making it through to record a heartbeat.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/363)

<!-- Reviewable:end -->
