### PR TITLE
Rename 'lochness' and 'mistify' to 'cerana'

### DIFF
--- a/cmd/clusterconfig-provider/config.json
+++ b/cmd/clusterconfig-provider/config.json
@@ -1,6 +1,6 @@
 {
     "service_name": "systemd-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock",
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock",
     "dataset-ttl": "1m",
     "bundle-ttl": "1m",
     "node-ttl": "1m"

--- a/cmd/datatrade-provider/config.json
+++ b/cmd/datatrade-provider/config.json
@@ -1,5 +1,5 @@
 {
     "service_name": "systemd-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock",
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock",
     "node_coordinator_port": 8080
 }

--- a/cmd/health-provider/config.json
+++ b/cmd/health-provider/config.json
@@ -1,4 +1,4 @@
 {
     "service_name": "health-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock"
 }

--- a/cmd/metrics-provider/config.json
+++ b/cmd/metrics-provider/config.json
@@ -1,4 +1,4 @@
 {
     "service_name": "metrics-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock"
 }

--- a/cmd/namespace-provider/config.json
+++ b/cmd/namespace-provider/config.json
@@ -1,4 +1,4 @@
 {
     "service_name": "namespace-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock"
 }

--- a/cmd/service-provider/config.json
+++ b/cmd/service-provider/config.json
@@ -1,4 +1,4 @@
 {
     "service_name": "service-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock"
 }

--- a/cmd/systemd-provider/config.json
+++ b/cmd/systemd-provider/config.json
@@ -1,4 +1,4 @@
 {
     "service_name": "systemd-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock"
 }

--- a/cmd/zfs-provider/config.json
+++ b/cmd/zfs-provider/config.json
@@ -1,4 +1,4 @@
 {
     "service_name": "zfs-provider",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock"
 }

--- a/internal/tests/common/ct.go
+++ b/internal/tests/common/ct.go
@@ -91,7 +91,7 @@ type Suite struct {
 // SetupSuite runs a new kv instance.
 func (s *Suite) SetupSuite() {
 	if s.TestPrefix == "" {
-		s.TestPrefix = "lochness-test"
+		s.TestPrefix = "cerana-test"
 	}
 
 	s.KVDir, _ = ioutil.TempDir("", s.TestPrefix+"-"+uuid.New())
@@ -128,7 +128,7 @@ func (s *Suite) SetupSuite() {
 		panic(err)
 	}
 
-	s.KVPrefix = "lochness"
+	s.KVPrefix = "cerana"
 	s.KVURL = "http://127.0.0.1:" + strconv.Itoa(int(s.KVPort))
 }
 

--- a/pkg/kv/kv_test.go
+++ b/pkg/kv/kv_test.go
@@ -133,8 +133,8 @@ func (s *KVSuite) TestPing() {
 }
 
 func (s *KVSuite) TestIsKeyNotFound() {
-	s.Require().Panics(func() { get(s.KVPort, "lochness/non-existent-key") })
-	_, err := s.KV.Get("lochness/non-existent-key")
+	s.Require().Panics(func() { get(s.KVPort, "cerana/non-existent-key") })
+	_, err := s.KV.Get("cerana/non-existent-key")
 	s.Require().True(s.KV.IsKeyNotFound(err))
 }
 
@@ -241,19 +241,19 @@ func (s *KVSuite) TestUpdate() {
 	_, err := s.KV.Update("some-key", kv.Value{})
 	s.Require().Error(err)
 
-	_, err = s.KV.Get("lochness/some-key")
+	_, err = s.KV.Get("cerana/some-key")
 	s.Require().True(s.KV.IsKeyNotFound(err))
 
-	idx, err := s.KV.Update("lochness/some-key", kv.Value{Data: []byte("1")})
+	idx, err := s.KV.Update("cerana/some-key", kv.Value{Data: []byte("1")})
 	s.Require().NoError(err)
 	s.Require().True(idx > 0)
 
-	_, err = s.KV.Update("lochness/some-key", kv.Value{Data: []byte("2")})
+	_, err = s.KV.Update("cerana/some-key", kv.Value{Data: []byte("2")})
 	s.Require().Error(err)
-	_, err = s.KV.Update("lochness/some-key", kv.Value{Data: []byte("2"), Index: idx - 1})
+	_, err = s.KV.Update("cerana/some-key", kv.Value{Data: []byte("2"), Index: idx - 1})
 	s.Require().Error(err)
 
-	idx2, err := s.KV.Update("lochness/some-key", kv.Value{Data: []byte("2"), Index: idx})
+	idx2, err := s.KV.Update("cerana/some-key", kv.Value{Data: []byte("2"), Index: idx})
 	s.Require().NoError(err)
 	s.Require().True(idx2 > idx)
 }
@@ -261,35 +261,35 @@ func (s *KVSuite) TestUpdate() {
 func (s *KVSuite) TestRemove() {
 	s.Require().NoError(s.KV.Remove("some-random-key", 0))
 
-	idx, err := s.KV.Update("lochness/some-key", kv.Value{Data: []byte("1")})
+	idx, err := s.KV.Update("cerana/some-key", kv.Value{Data: []byte("1")})
 	s.Require().NoError(err)
 	s.Require().True(idx > 0)
 
-	s.Require().Error(s.KV.Remove("lochness/some-key", idx-1))
-	v, err := s.KV.Get("lochness/some-key")
+	s.Require().Error(s.KV.Remove("cerana/some-key", idx-1))
+	v, err := s.KV.Get("cerana/some-key")
 	s.Require().NoError(err)
 	s.Require().True(v.Index == idx)
 	s.Require().Equal([]byte("1"), v.Data)
 
-	s.Require().Error(s.KV.Remove("lochness/some-key", idx+1))
-	v, err = s.KV.Get("lochness/some-key")
+	s.Require().Error(s.KV.Remove("cerana/some-key", idx+1))
+	v, err = s.KV.Get("cerana/some-key")
 	s.Require().NoError(err)
 	s.Require().True(v.Index == idx)
 	s.Require().Equal([]byte("1"), v.Data)
 
-	s.Require().NoError(s.KV.Remove("lochness/some-key", idx))
-	_, err = s.KV.Get("lochness/some-key")
+	s.Require().NoError(s.KV.Remove("cerana/some-key", idx))
+	_, err = s.KV.Get("cerana/some-key")
 	s.Require().Error(err)
 	s.Require().True(s.KV.IsKeyNotFound(err))
 }
 
 func (s *KVSuite) TestWatch() {
-	index, err := s.KV.Update("lochness/some-key", kv.Value{Data: []byte("1")})
+	index, err := s.KV.Update("cerana/some-key", kv.Value{Data: []byte("1")})
 	s.Require().NoError(err)
 	s.Require().True(index > 0)
 
 	stop := make(chan struct{})
-	events, errors, err := s.KV.Watch("lochness/", index, stop)
+	events, errors, err := s.KV.Watch("cerana/", index, stop)
 	s.Require().NoError(err)
 	s.Require().NotNil(events)
 	s.Require().NotNil(errors)
@@ -312,7 +312,7 @@ func (s *KVSuite) TestWatch() {
 		{name: "delete", eType: kv.Delete},
 	}
 
-	key := "lochness/watcher-test-key"
+	key := "cerana/watcher-test-key"
 	index = 0
 	for i := range tests {
 		t := &tests[i]
@@ -372,7 +372,7 @@ func (s *KVSuite) makeEKey(key string) kv.EphemeralKey {
 }
 
 func (s *KVSuite) TestEphemeralSet() {
-	key := "lochness/ekey-set"
+	key := "cerana/ekey-set"
 	ekey := s.makeEKey(key)
 
 	s.Require().NoError(ekey.Set("value"))
@@ -382,7 +382,7 @@ func (s *KVSuite) TestEphemeralSet() {
 }
 
 func (s *KVSuite) TestEphemeralDestroy() {
-	key := "lochness/ekey-destroy"
+	key := "cerana/ekey-destroy"
 	ekey := s.makeEKey(key)
 
 	s.Require().NoError(ekey.Renew())
@@ -394,7 +394,7 @@ func (s *KVSuite) TestEphemeralDestroy() {
 func (s *KVSuite) TestEphemeralRenew() {
 	s.T().Parallel()
 
-	key := "lochness/ekey-renew"
+	key := "cerana/ekey-renew"
 	ekey := s.makeEKey(key)
 
 	for i := 0; i < 5; i++ {
@@ -414,7 +414,7 @@ func (s *KVSuite) TestEphemeralRenew() {
 func (s *KVSuite) TestLock() {
 	s.T().Parallel()
 
-	key := "lochness/lock"
+	key := "cerana/lock"
 
 	// acquire lock
 	lock, err := s.KV.Lock(key, 1*time.Second)

--- a/provider/examples/simple/cmd/provider-simple/config.json
+++ b/provider/examples/simple/cmd/provider-simple/config.json
@@ -1,4 +1,4 @@
 {
     "service_name": "provider-simple",
-    "coordinator_url": "unix:///tmp/mistify/coordinator/coordinator.sock"
+    "coordinator_url": "unix:///tmp/cerana/coordinator/coordinator.sock"
 }

--- a/run-test.sh
+++ b/run-test.sh
@@ -18,7 +18,7 @@ cid=$(docker run -dti \
 	--env     TMPDIR=$(mktemp -d) \
 	--env     KV=${KV:-consul} \
 	--name    $name \
-	--volume  $PWD:/mistify:ro \
+	--volume  $PWD:/cerana:ro \
 	--volume  /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	--volume  /tmp:/tmp \
 	mistifyio/mistify-os:zfs-stable-api
@@ -30,7 +30,7 @@ sleep .25
 docker cp $(which consul) $cid:/usr/bin/
 docker cp $(which etcd) $cid:/usr/bin/
 
-docker exec $cid sh -c "cd /mistify/$dir; ./$name -test.v" >&2 || ret=$?;
+docker exec $cid sh -c "cd /cerana/$dir; ./$name -test.v" >&2 || ret=$?;
 
 docker kill  $cid > /dev/null || :
 docker rm -v $cid > /dev/null || :


### PR DESCRIPTION
#### Description:

Rename occurances of 'lochness' and 'mistify' to 'cerana'

Two exceptions:
1. A mention of 'mistify' in an old presentation docs/zfs/Sandboxing OpenZFS on Linux.pdf
1. Use of the `mistifyio/mistify-os:zfs-stable-api` docker image in run-test.sh
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #249

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/368)

<!-- Reviewable:end -->
