### PR TITLE
Acomm debug logging

### DIFF
--- a/acomm/request_test.go
+++ b/acomm/request_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cerana/cerana/acomm"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
@@ -15,10 +14,6 @@ import (
 
 type RequestTestSuite struct {
 	suite.Suite
-}
-
-func (s *RequestTestSuite) SetupSuite() {
-	logrus.SetLevel(logrus.FatalLevel)
 }
 
 func TestRequestTestSuite(t *testing.T) {

--- a/acomm/response.go
+++ b/acomm/response.go
@@ -109,7 +109,7 @@ func sendUnix(addr *url.URL, payload interface{}) error {
 	if err != nil {
 		return errors.Wrapv(err, map[string]interface{}{"addr": addr, "payload": payload})
 	}
-	defer logrusx.LogReturnedErr(conn.Close,
+	defer logrusx.DebugReturnedErr(conn.Close,
 		map[string]interface{}{"addr": addr},
 		"failed to close unix connection",
 	)
@@ -137,7 +137,7 @@ func sendHTTP(addr *url.URL, payload interface{}) error {
 	if err != nil {
 		return errors.Wrapv(err, map[string]interface{}{"addr": addr, "payload": payload})
 	}
-	defer logrusx.LogReturnedErr(httpResp.Body.Close, nil, "failed to close http body")
+	defer logrusx.DebugReturnedErr(httpResp.Body.Close, nil, "failed to close http body")
 
 	body, _ := ioutil.ReadAll(httpResp.Body)
 	resp := &Response{}

--- a/acomm/response_test.go
+++ b/acomm/response_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cerana/cerana/acomm"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
@@ -24,7 +23,6 @@ type ResponseTestSuite struct {
 }
 
 func (s *ResponseTestSuite) SetupSuite() {
-	logrus.SetLevel(logrus.FatalLevel)
 	s.Responses = make(chan *acomm.Response, 10)
 }
 

--- a/acomm/stream.go
+++ b/acomm/stream.go
@@ -33,7 +33,7 @@ func (t *Tracker) NewStreamUnix(dir string, src io.ReadCloser) (*url.URL, error)
 
 	go func() {
 		defer func() {
-			logrusx.LogReturnedErr(src.Close, map[string]interface{}{"socketPath": socketPath}, "failed to close stream source")
+			logrusx.DebugReturnedErr(src.Close, map[string]interface{}{"socketPath": socketPath}, "failed to close stream source")
 
 			t.dsLock.Lock()
 			delete(t.dataStreams, socketPath)
@@ -48,7 +48,7 @@ func (t *Tracker) NewStreamUnix(dir string, src io.ReadCloser) (*url.URL, error)
 
 		if _, err := io.Copy(conn, src); err != nil {
 			err = errors.Wrapv(err, map[string]interface{}{"socketPath": socketPath}, "failed to stream data")
-			logrus.WithField("error", err).Error(err.Error())
+			logrus.WithField("error", err).Debug(err.Error())
 			return
 		}
 	}()
@@ -100,7 +100,7 @@ func streamUnix(dest io.Writer, addr *url.URL) error {
 	if err != nil {
 		return errors.Wrapv(err, map[string]interface{}{"addr": addr})
 	}
-	defer logrusx.LogReturnedErr(conn.Close,
+	defer logrusx.DebugReturnedErr(conn.Close,
 		map[string]interface{}{"addr": addr},
 		"failed to close stream connection",
 	)
@@ -115,7 +115,7 @@ func streamHTTP(dest io.Writer, addr *url.URL) error {
 	if err != nil {
 		return errors.Wrapv(err, map[string]interface{}{"addr": addr})
 	}
-	defer logrusx.LogReturnedErr(httpResp.Body.Close,
+	defer logrusx.DebugReturnedErr(httpResp.Body.Close,
 		map[string]interface{}{"addr": addr},
 		"failed to close stream response body",
 	)
@@ -135,7 +135,7 @@ func ProxyStreamHandler(w http.ResponseWriter, r *http.Request) {
 	if err := Stream(w, addr); err != nil {
 		if _, ok := errors.Cause(err).(*net.OpError); ok {
 			// TODO: find out what the result is for "not-exist" and return 404
-			logrus.WithField("error", err).Error("failed to stream data")
+			logrus.WithField("error", err).Debug("failed to stream data")
 		}
 		http.Error(w, "failed to stream data", http.StatusInternalServerError)
 		return

--- a/acomm/tracker_test.go
+++ b/acomm/tracker_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cerana/cerana/acomm"
 	"github.com/stretchr/testify/suite"
 )
@@ -27,7 +26,6 @@ type TrackerTestSuite struct {
 }
 
 func (s *TrackerTestSuite) SetupSuite() {
-	logrus.SetLevel(logrus.FatalLevel)
 	s.Responses = make(chan *acomm.Response, 10)
 
 	// Mock HTTP response server

--- a/acomm/unixlistener.go
+++ b/acomm/unixlistener.go
@@ -99,7 +99,7 @@ func (ul *UnixListener) createListener() error {
 // limit.
 func (ul *UnixListener) listen() {
 	defer ul.waitgroup.Done()
-	defer logrusx.LogReturnedErr(ul.listener.Close, map[string]interface{}{
+	defer logrusx.DebugReturnedErr(ul.listener.Close, map[string]interface{}{
 		"addr": ul.Addr(),
 	}, "failed to close listener")
 
@@ -115,7 +115,7 @@ func (ul *UnixListener) listen() {
 
 		if err := ul.listener.SetDeadline(time.Now().Add(time.Second)); err != nil {
 			err = errors.Wrapv(err, map[string]interface{}{"addr": ul.Addr()})
-			logrus.WithField("error", err).Error("failed to set listener deadline")
+			logrus.WithField("error", err).Debug("failed to set listener deadline")
 		}
 
 		conn, err := ul.listener.Accept()
@@ -126,7 +126,7 @@ func (ul *UnixListener) listen() {
 				continue
 			}
 
-			logrus.WithField("error", err).Error("failed to accept new connection")
+			logrus.WithField("error", err).Debug("failed to accept new connection")
 			continue
 		}
 
@@ -167,7 +167,7 @@ func (ul *UnixListener) DoneConn(conn net.Conn) {
 	if conn == nil {
 		return
 	}
-	logrusx.LogReturnedErr(conn.Close,
+	logrusx.DebugReturnedErr(conn.Close,
 		map[string]interface{}{
 			"addr": ul.addr,
 		}, "failed to close unix connection",

--- a/pkg/logrusx/ext.go
+++ b/pkg/logrusx/ext.go
@@ -26,12 +26,22 @@ func SetLevel(logLevel string) error {
 }
 
 // LogReturnedErr wraps a function that returns an error, calls the function,
-// and logs any error.
+// and logs any error at the Error level.
 // Useful for basic defer, e.g.
 // `defer LogReturnedErr(f.Close,logrus.Fields{"file":f.Name()}, "failed to close file")`
 func LogReturnedErr(fn func() error, fields map[string]interface{}, message string) {
 	if err := fn(); err != nil {
 		logrus.WithField("error", errors.Wrapv(err, fields)).Error(message)
+	}
+}
+
+// DebugReturnedErr wraps a function that returns an error, calls the function,
+// and logs any error at the Debug level.
+// Useful for basic defer, e.g.
+// `defer DebugReturnedErr(f.Close,logrus.Fields{"file":f.Name()}, "failed to close file")`
+func DebugReturnedErr(fn func() error, fields map[string]interface{}, message string) {
+	if err := fn(); err != nil {
+		logrus.WithField("error", errors.Wrapv(err, fields)).Debug(message)
 	}
 }
 


### PR DESCRIPTION
#### Description:

Some errors, such as those from deferred calls or ones generated in
goroutines, can't make it out to the package caller but can't be handled
either. It is up to the caller to verify and handle the visible result.
Debug logging can be turned on to aid in manual investigation.
#### Issues affected:

<!-- See https://github.com/blog/1506-closing-issues-via-pull-requests -->

Resolves #308

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cerana/cerana/369)

<!-- Reviewable:end -->
